### PR TITLE
Use correct type for precert_entry_V2 in TimestampedEntry.signed_entry.

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -694,7 +694,7 @@ for misbehavior, has had a key compromise or is not known to the client).
         LogEntryType entry_type;
         select(entry_type) {
             case x509_entry: ASN.1Cert;
-            case precert_entry_V2: PreCert;
+            case precert_entry_V2: TBSCertificate;
         } signed_entry;
         CtExtensions extensions;
     } TimestampedEntry;


### PR DESCRIPTION
This bug must've crept in when we updated the Precertificate format.
"PreCert" is no longer defined or used anywhere else.