### PR TITLE
Remove unreferenced LogEntry structure

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -380,14 +380,6 @@ following components:
   <artwork>
     enum { x509_entry(0), precert_entry_V2(3), (65535) } LogEntryType;
 
-    struct {
-        LogEntryType entry_type;
-        select (entry_type) {
-            case x509_entry: X509ChainEntry;
-            case precert_entry_V2: PrecertChainEntryV2;
-        } entry;
-    } LogEntry;
-
     opaque ASN.1Cert&lt;1..2^24-1&gt;;
 
     struct {


### PR DESCRIPTION
The `LogEntryType` enum is used in a number of places, but the `LogEntry`
structure is never used anywhere.  I remember this causing me no end of
confusion when I was grappling with understanding RFC6962, and since the
structure hasn't seen any new use since, I'm thinking it can probably stand
to go.