### PR TITLE
Make /get-entries?end= optional

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -1179,7 +1179,7 @@ an accepted root certificate.
 
       <section title="Retrieve Entries from Log" anchor="fetch_entries">
         <t>
-          GET https://&lt;log server&gt;/ct/v1/get-entries
+          GET https://&lt;log server&gt;/ct/v2/get-entries
         </t>
         <t>
 	  <list style="hanging">
@@ -1189,7 +1189,7 @@ an accepted root certificate.
 		  0-based index of first entry to retrieve, in decimal.
 		</t>
 		<t hangText="end:">
-		  0-based index of last entry to retrieve, in decimal.
+		  (optional) 0-based index of last entry to retrieve, in decimal.  If this parameter is not specified, then the log should treat it as being equal to the <spanx style="verb">tree_size - 1</spanx>.
 		</t>
               </list>
 	    </t>


### PR DESCRIPTION
Given:

1. There is no way to know, in advance, the maximum number of entries which a log will return from a /get-entries call; and

2. Some logs will return a 400 if you ask for an `end` which is >= tree_size; and

2. It is inefficient to require a call to /get-sth to get the tree size before each request to /get-entries; and

4. I can think of no reason why the log shouldn't be able to easily introspect its size to determine where to end.

Therefore, be it resolved that I have submitted this Pull Request for your kind and valuable consideration.  <grin>

In practice, it makes writing a monitor that much easier if I don't have to keep track of where the end might be, and make sure I don't run off the end of it.