### PR TITLE
Use LogEntryType 2.

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -378,7 +378,7 @@ following components:
         </t>
 <figure>
   <artwork>
-   enum { x509_entry(0), precert_entry_V2(3), (65535) } LogEntryType;
+   enum { x509_entry(0), precert_entry_V2(2), (65535) } LogEntryType;
 
    opaque ASN.1Cert&lt;1..2^24-1&gt;;
 


### PR DESCRIPTION
RFC6962 only uses 0 and 1.
We almost used 2 for an x509_entry_V2, but later concluded that we didn't need it (hence the current use of 3 rather than 2 for precert_entry_V2).
Let's use 2 rather than skip over it unnecessarily.