### PR TITLE
Correct versioning of some calls.

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -874,7 +874,7 @@ messages.
       <t>
         <figure>
           <preamble>
-            e.g. In response to a request of <spanx style="verb">/ct/v1/get-entries?start=100&amp;end=99</spanx>, the log would return a <spanx style="verb">400 Bad Request</spanx> response code with a body similar to the following:
+            e.g. In response to a request of <spanx style="verb">/ct/v2/get-entries?start=100&amp;end=99</spanx>, the log would return a <spanx style="verb">400 Bad Request</spanx> response code with a body similar to the following:
           </preamble>
           <artwork>
   {
@@ -935,7 +935,7 @@ messages.
 
       <section title="Add PreCertChain to Log">
         <t>
-          POST https://&lt;log server&gt;/ct/v1/add-pre-chain
+          POST https://&lt;log server&gt;/ct/v2/add-pre-chain
         </t>
 	<t>
 	  <list style="hanging">


### PR DESCRIPTION
The example using v1 get-entries is bad as a v1 log is unlikely to return the
error codes described in bis.

add-pre-chain requires a version upgrade as it's specified to return the same
outputs as add-chain, which now returns the SCT in binary format.

get-sth may need updating as well since entries are structured differently.