### PR TITLE
Remove mentioning of DANE and self-signed certificates.

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -368,7 +368,7 @@ MUST reject certificates without a valid signature chain to an accepted root
 certificate. Logs MUST also reject precertificates that are not valid DER encoded CMS <spanx style="verb">signed-data</spanx> objects.
         </t>
         <t>
-          If a certificate is accepted and an SCT issued, the accepting log MUST store the entire chain used for verification. This chain MUST include the certificate or precertificate itself, the zero or more intermediate CA certificates provided by the submitter, and the root certificate used to verify the chain (even if it was omitted from the submission). The log MUST present this chain for auditing upon request. This chain is required to prevent a CA from avoiding blame by logging a partial or empty chain. (Note: This effectively excludes self-signed and DANE-based certificates until some mechanism to limit the submission of spurious certificates is found. The authors welcome suggestions.)
+          If a certificate is accepted and an SCT issued, the accepting log MUST store the entire chain used for verification. This chain MUST include the certificate or precertificate itself, the zero or more intermediate CA certificates provided by the submitter, and the root certificate used to verify the chain (even if it was omitted from the submission). The log MUST present this chain for auditing upon request. This chain is required to prevent a CA from avoiding blame by logging a partial or empty chain.
         </t>
         <figure>
           <preamble>


### PR DESCRIPTION
This spec focuses on CA-issued X.509 certificates, so calling for suggestions
for DANE and self-signed certificates is irrelevant.