### PR TITLE
Reorganize requirements into appropriate sections

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -440,11 +440,11 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
       </section>
       <section title="Log Entries">
         <t>
-          If a certificate is accepted and an SCT issued, the accepting log MUST store the entire chain used for verification. This chain MUST include the certificate or precertificate itself, the zero or more intermediate CA certificates provided by the submitter, and the root certificate used to verify the chain (even if it was omitted from the submission). The log MUST present this chain for auditing upon request. This chain is required to prevent a CA from avoiding blame by logging a partial or empty chain.
+          If a submission is accepted and an SCT issued, the accepting log MUST store the entire chain used for verification. This chain MUST include the certificate or precertificate itself, the zero or more intermediate CA certificates provided by the submitter, and the root certificate used to verify the chain (even if it was omitted from the submission). The log MUST present this chain for auditing upon request. This chain is required to prevent a CA from avoiding blame by logging a partial or empty chain.
         </t>
         <figure>
           <preamble>
-            Each certificate or precertificate entry in a log MUST include the following components:
+            Each certificate entry in a log MUST include a <spanx style="verb">X509ChainEntry</spanx> structure, and each precertificate entry MUST include a <spanx style="verb">PrecertChainEntryV2</spanx> structure:
           </preamble>
           <artwork>
     enum {
@@ -469,16 +469,16 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
           <spanx style="verb">entry_type</spanx> is the type of this entry. Future revisions of this protocol may add new LogEntryType values. <xref target="client_messages"/> explains how clients should handle unknown entry types.
         </t>
         <t>
-          <spanx style="verb">leaf_certificate</spanx> is the end-entity certificate submitted for auditing.
+          <spanx style="verb">leaf_certificate</spanx> is a submitted certificate that has been accepted by the log.
         </t>
         <t>
-          <spanx style="verb">certificate_chain</spanx> is an array of additional certificates required to verify the end-entity certificate. The first certificate MUST certify the end-entity certificate. Each following certificate MUST directly certify the one preceding it. The final certificate MUST either be, or be issued by, a root certificate accepted by the log. If the end-entity certificate is a root certificate, then this array is empty.
+          <spanx style="verb">certificate_chain</spanx> is a vector of 0 or more additional certificates required to verify <spanx style="verb">leaf_certificate</spanx>. The first certificate MUST certify <spanx style="verb">leaf_certificate</spanx>. Each following certificate MUST directly certify the one preceding it. The final certificate MUST be a root certificate accepted by the log. If <spanx style="verb">leaf_certificate</spanx> is a root certificate, then this vector is empty.
         </t>
         <t>
-          <spanx style="verb">pre_certificate</spanx> is the precertificate submitted for auditing.
+          <spanx style="verb">pre_certificate</spanx> is a submitted precertificate that has been accepted by the log.
         </t>
         <t>
-          <spanx style="verb">precertificate_chain</spanx> is a chain of additional certificates required to verify the precertificate submission. The first certificate MUST certify the precertificate. Each following certificate MUST directly certify the one preceding it. The final certificate MUST be a root certificate accepted by the log.
+          <spanx style="verb">precertificate_chain</spanx> is a vector of 1 or more additional certificates required to verify <spanx style="verb">pre_certificate</spanx>. The first certificate MUST certify <spanx style="verb">pre_certificate</spanx>. Each following certificate MUST directly certify the one preceding it. The final certificate MUST be a root certificate accepted by the log.
         </t>
       </section>
       <section title="Structure of the Signed Certificate Timestamp">

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -1145,10 +1145,7 @@ entry specified by <spanx style="verb">start</spanx>.
       </t>
       <section title="TLS Extension" anchor="tls_sctlist_extension">
         <t>
-          If a TLS client includes the <spanx style="verb">signed_certificate_timestamp</spanx> extension type in the ClientHello, the TLS server MAY include the <spanx style="verb">signed_certificate_timestamp</spanx> extension in the ServerHello with the <spanx style="verb">extension_data</spanx> set to a <spanx style="verb">SignedCertificateTimestampList</spanx>.
-        </t>
-        <t>
-          Session resumption uses the original session information: TLS clients SHOULD include the extension type in the ClientHello, but if the session is resumed, the TLS server is not expected to process it or include the extension in the ServerHello.
+          If a TLS client includes the <spanx style="verb">signed_certificate_timestamp</spanx> extension type in the ClientHello, the TLS server MAY include the <spanx style="verb">signed_certificate_timestamp</spanx> extension in the ServerHello with <spanx style="verb">extension_data</spanx> set to a <spanx style="verb">SignedCertificateTimestampList</spanx>. The TLS server is not expected to process or include this extension when a TLS session is resumed, since session resumption uses the original session information.
         </t>
       </section>
     </section>

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -305,6 +305,11 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
         </section>
       </section>
     </section>
+    <section title="Submitters">
+      <t>
+        Submitters submit certificates or precertificates to the log as described above. When a Submitter intends to use the returned SCT directly in a TLS handshake or to construct a certificate, they SHOULD validate the SCT as described in <xref target="tls_clients"/> if they understand its format.
+      </t>
+    </section>
     <section title="Log Format and Operation">
       <t>
         Anyone can submit certificates to certificate logs for public auditing;
@@ -1330,11 +1335,6 @@ but it is expected there will be a variety.
         </list></t>
         <t>
           <xref target="JSON.Metadata"/> is an example of a metadata format which includes the above elements.
-        </t>
-      </section>
-      <section title="Submitters">
-        <t>
-          Submitters submit certificates or precertificates to the log as described above. When a Submitter intends to use the returned SCT directly in a TLS handshake or to construct a certificate, they SHOULD validate the SCT as described in <xref target="tls_clients"/> if they understand its format.
         </t>
       </section>
       <section title="TLS Client" anchor="tls_clients">

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -1113,7 +1113,7 @@ entry specified by <spanx style="verb">start</spanx>.
     </section>
     <section title="TLS Servers">
       <t>
-        TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate. A certificate not accompanied by an SCT (either for the end-entity certificate or for a name-constrained intermediate the end-entity certificate chains to) MUST NOT be considered compliant by TLS clients.
+        TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate.
       </t>
       <t>
         The SCT data corresponding to at least one certificate in the chain from at least one log must be included in the TLS handshake by using one or more of the mechanisms listed below. Three mechanisms are provided because they have different tradeoffs. TLS clients MUST implement all three mechanisms. TLS servers MUST present SCTs using at least one of the three mechanisms.
@@ -1251,11 +1251,7 @@ but it is expected there will be a variety.
       </section>
       <section title="TLS Client" anchor="tls_clients">
         <t>
-          TLS clients receive SCTs alongside or in certificates, either for the server certificate itself or for intermediate CA precertificates. In
-addition to normal validation of the certificate and its chain, TLS clients
-SHOULD validate the SCT by computing the signature input from the SCT data as
-well as the certificate and verifying the signature, using the corresponding
-log's public key. By validating SCTs, TLS clients can thus determine whether certificates are compliant. However, specifying the TLS clients' behaviour once compliance or non-compliance has been determined (for example, whether a certificate should be rejected due to the lack of valid SCTs) is outside the scope of this document.
+          TLS clients receive SCTs alongside or in certificates, either for the server certificate itself or for a name-constrained intermediate the server certificate chains to. In addition to normal validation of the certificate and its chain, TLS clients SHOULD validate the SCT by computing the signature input from the SCT data as well as the certificate and verifying the signature, using the corresponding log's public key. By validating SCTs, TLS clients can thus determine whether certificates are compliant. A certificate not accompanied by a valid SCT MUST NOT be considered compliant by TLS clients. However, specifying the TLS clients' behavior once compliance or non-compliance has been determined (for example, whether a certificate should be rejected due to the lack of valid SCTs) is outside the scope of this document.
         </t>
         <t>
           A TLS client MAY audit the corresponding log by requesting, and

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -312,6 +312,10 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
       <t>
         If a log accepts a submission, it will return a Signed Certificate Timestamp (SCT). The submitter SHOULD validate the returned SCT as described in <xref target="tls_clients"/> if they understand its format and they intend to use it directly in a TLS handshake or to construct a certificate.
       </t>
+      <section title="Certificates">
+      </section>
+      <section title="Precertificates">
+      </section>
     </section>
     <section title="Log Format and Operation">
       <t>

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -1235,7 +1235,8 @@ entry specified by <spanx style="verb">start</spanx>.
         </t>
       </section>
     </section>
-
+    <section title="TLS Servers">
+    </section>
     <section title="Clients">
       <t>
         There are various different functions clients of logs might perform. We

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -322,29 +322,24 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
           Alternatively, (root as well as intermediate) CAs may preannounce a certificate prior to issuance by <xref target="add_pre_chain">submitting a precertificate</xref> that the log can use to create an entry that will be valid against the issued certificate. The CA MAY incorporate the returned SCT in the issued certificate.
         </t>
         <t>
-          A precertificate is a CMS <xref target="RFC5652"/>
-<spanx style="verb">signed-data</spanx> object that contains a TBSCertificate
-<xref target="RFC5280"/> in its
-<spanx style="verb">SignedData.encapContentInfo.eContent</spanx> field,
-identified by the OID &lt;TBD&gt; in the
-<spanx style="verb">SignedData.encapContentInfo.eContentType</spanx> field.
-This TBSCertificate MAY redact certain domain name labels that will be present
-in the issued certificate (see <xref target="redacting_subdomains"/>) and MUST
-NOT contain any SCTs, but it will be otherwise identical to the TBSCertificate
-in the issued certificate.
-<spanx style="verb">SignedData.signerInfos</spanx> MUST contain a signature from
-the same (root or intermediate) CA that will ultimately issue the certificate.
-This signature indicates the certification authority's intent to issue the
-certificate. This intent is considered binding (i.e., misissuance of the
-precertificate is considered equivalent to misissuance of the certificate).
-As above, the precertificate submission MUST be accompanied by all the
-additional certificates required to verify the chain up to an accepted root
-certificate. This does not involve using the
-<spanx style="verb">SignedData.certificates</spanx> field, so that field SHOULD
-be omitted.
-        </t>
-        <t>
-          The CMS object MUST be DER encoded. Note that, because of the structure of CMS, the signature on the CMS object will not be a valid X.509v3 signature and so cannot be used to construct a certificate from the precertificate.
+          A precertificate is a CMS <xref target="RFC5652"/> <spanx style="verb">signed-data</spanx> object that conforms to the following requirements:
+          <list style="symbols">
+            <t>
+              It MUST be DER encoded.
+            </t>
+            <t>
+              <spanx style="verb">SignedData.encapContentInfo.eContentType</spanx> MUST be the OID &lt;TBD&gt;.
+            </t>
+            <t>
+              <spanx style="verb">SignedData.encapContentInfo.eContent</spanx> MUST contain a TBSCertificate <xref target="RFC5280"/>, which MAY redact certain domain name labels that will be present in the issued certificate (see <xref target="redacting_subdomains"/>) and MUST NOT contain any SCTs, but which will be otherwise identical to the TBSCertificate in the issued certificate.
+            </t>
+            <t>
+              <spanx style="verb">SignedData.signerInfos</spanx> MUST contain a signature from the same (root or intermediate) CA that will ultimately issue the certificate. This signature indicates the CA's intent to issue the certificate. This intent is considered binding (i.e. misissuance of the precertificate is considered equivalent to misissuance of the certificate). (Note that, because of the structure of CMS, the signature on the CMS object will not be a valid X.509v3 signature and so cannot be used to construct a certificate from the precertificate).
+            </t>
+            <t>
+              <spanx style="verb">SignedData.certificates</spanx> SHOULD be omitted.
+            </t>
+          </list>
         </t>
       </section>
     </section>

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -314,12 +314,12 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
       </t>
       <section title="Certificates">
         <t>
-          Anyone can <xref target="add_chain">submit a certificate</xref> to a log. Since certificates may not be accepted by TLS clients unless logged, it is expected that certificate owners or their CAs will usually submit them.
+          Anyone can <xref target="add-chain">submit a certificate</xref> to a log. Since certificates may not be accepted by TLS clients unless logged, it is expected that certificate owners or their CAs will usually submit them.
         </t>
       </section>
       <section title="Precertificates">
         <t>
-          Alternatively, (root as well as intermediate) CAs may preannounce a certificate prior to issuance by <xref target="add_pre_chain">submitting a precertificate</xref> that the log can use to create an entry that will be valid against the issued certificate. The CA MAY incorporate the returned SCT in the issued certificate.
+          Alternatively, (root as well as intermediate) CAs may preannounce a certificate prior to issuance by <xref target="add-pre-chain">submitting a precertificate</xref> that the log can use to create an entry that will be valid against the issued certificate. The CA MAY incorporate the returned SCT in the issued certificate.
         </t>
         <t>
           A precertificate is a CMS <xref target="RFC5652"/> <spanx style="verb">signed-data</spanx> object that conforms to the following requirements:
@@ -933,7 +933,7 @@ messages.
       <t>
         Clients SHOULD treat <spanx style="verb">500 Internal Server Error</spanx> and <spanx style="verb">503 Service Unavailable</spanx> responses as transient failures and MAY retry the same request without modification at a later date.  Note that as per <xref target="RFC2616"/>, in the case of a 503 response the log MAY include a <spanx style="verb">Retry-After:</spanx> header in order to request a minimum time for the client to wait before retrying the request.
       </t>
-      <section title="Add Chain to Log" anchor="add_chain">
+      <section title="Add Chain to Log" anchor="add-chain">
         <t>
           POST https://&lt;log server&gt;/ct/v2/add-chain
         </t>
@@ -979,7 +979,7 @@ messages.
         </t>
       </section>
 
-      <section title="Add PreCertChain to Log" anchor="add_pre_chain">
+      <section title="Add PreCertChain to Log" anchor="add-pre-chain">
         <t>
           POST https://&lt;log server&gt;/ct/v2/add-pre-chain
         </t>
@@ -1001,7 +1001,7 @@ an accepted root certificate.
           </list>
         </t>
         <t>
-          Outputs and errors are the same as in <xref target="add_chain"/>.
+          Outputs and errors are the same as in <xref target="add-chain"/>.
         </t>
       </section>
 

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -307,7 +307,7 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
     </section>
     <section title="Submitters">
       <t>
-        Submitters submit certificates or precertificates to logs for public auditing, as described below. In order to enable attribution of each logged certificate to its issuer, each submitted certificate MUST be accompanied by all additional certificates required to verify the certificate chain up to an accepted root certificate. The root certificate itself MAY be omitted from the chain submitted to the log server.
+        Submitters submit certificates or precertificates to logs for public auditing, as described below. In order to enable attribution of each logged certificate or precertificate to its issuer, each submission MUST be accompanied by all additional certificates required to verify the chain up to an accepted root certificate. The root certificate itself MAY be omitted from the submission.
       </t>
       <t>
         When a Submitter intends to use the returned SCT directly in a TLS handshake or to construct a certificate, they SHOULD validate the SCT as described in <xref target="tls_clients"/> if they understand its format.

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -416,13 +416,12 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
     </section>
     <section title="Log Format and Operation">
       <t>
-        A log is a single, append-only Merkle Tree of such certificates.
+        A log is a single, append-only Merkle Tree of submitted certificate and precertificate entries.
       </t>
       <t>
-        The SCT is the log's promise to incorporate the certificate in the Merkle Tree within a fixed amount of time known as the Maximum Merge Delay (MMD). If the log has previously seen the certificate, it MAY return the same SCT as it returned before (note that if a certificate was previously logged as a precertificate, then the precertificate's SCT would not be appropriate, instead a fresh SCT of type x509_entry should be generated).
+        When it receives a valid submission, the log MUST return an SCT that corresponds to the submitted certificate or precertificate. If the log has previously seen this valid submission, it MAY return the same SCT as it returned before (note that if a certificate was previously logged as a precertificate, then the precertificate's SCT would not be appropriate, instead a fresh SCT of type x509_entry should be generated).
       </t>
-      <t>
-        Periodically, each log appends all its new entries to the Merkle Tree and signs the root of the tree. The log MUST incorporate a certificate in its Merkle Tree within the Maximum Merge Delay period after the issuance of the SCT. When encountering an SCT, an Auditor can verify that the certificate was added to the Merkle Tree within that timeframe.
+        An SCT is the log's promise to incorporate the submitted entry in its Merkle Tree no later than a fixed amount of time, known as the Maximum Merge Delay (MMD), after the issuance of the SCT. Periodically, the log MUST append all its new entries to its Merkle Tree and sign the root of the tree. This provides auditable evidence that the log kept all its promises.
       </t>
       <t>
         Log operators MUST NOT impose any conditions on retrieving or sharing data from the log.

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -419,7 +419,7 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
         A log is a single, append-only Merkle Tree of such certificates.
       </t>
       <t>
-        The SCT is the log's promise to incorporate the certificate in the Merkle Tree within a fixed amount of time known as the Maximum Merge Delay (MMD). If the log has previously seen the certificate, it MAY return the same SCT as it returned before (note that if a certificate was previously logged as a precertificate, then the precertificate's SCT would not be appropriate, instead a fresh SCT of type x509_entry should be generated). TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate. A certificate not accompanied by an SCT (either for the end-entity certificate or for a name-constrained intermediate the end-entity certificate chains to) MUST NOT be considered compliant by TLS clients.
+        The SCT is the log's promise to incorporate the certificate in the Merkle Tree within a fixed amount of time known as the Maximum Merge Delay (MMD). If the log has previously seen the certificate, it MAY return the same SCT as it returned before (note that if a certificate was previously logged as a precertificate, then the precertificate's SCT would not be appropriate, instead a fresh SCT of type x509_entry should be generated).
       </t>
       <t>
         Periodically, each log appends all its new entries to the Merkle Tree and signs the root of the tree. The log MUST incorporate a certificate in its Merkle Tree within the Maximum Merge Delay period after the issuance of the SCT. When encountering an SCT, an Auditor can verify that the certificate was added to the Merkle Tree within that timeframe.
@@ -583,130 +583,6 @@ protocol to which the SCT conforms. This version is v2. Note that <xref target="
         <t>
           <spanx style="verb">extensions</spanx> are future extensions to SignedCertificateTimestamp v2. Currently, no extensions are specified. If an implementation sees an extension that it does not understand, it SHOULD ignore that extension. Furthermore, an implementation MAY choose to ignore any extension(s) that it does understand.
         </t>
-      </section>
-      <section title="Including the Signed Certificate Timestamp in the TLS Handshake">
-        <t>
-          The SCT data corresponding to at least one certificate in the chain
-from at least one log must be included in the TLS handshake by using one or more
-of the mechanisms listed below. Three mechanisms are provided because they have
-different tradeoffs. TLS clients MUST implement all three mechanisms. TLS
-servers MUST present SCTs using at least one of the three mechanisms.
-          <list style="symbols">
-            <t>
-              A TLS extension (Section 7.4.1.4 of <xref target='RFC5246'/>) with
-type <spanx style="verb">signed_certificate_timestamp</spanx>
-(see <xref target="tls_sctlist_extension"/>). This mechanism allows TLS servers
-to participate in CT without the cooperation of CAs, unlike the other two
-mechanisms. It also allows SCTs to be updated on the fly.
-            </t>
-            <t>
-              An <xref target='RFC6960'>Online Certificate Status Protocol
-(OCSP)</xref> response extension (see <xref target="ocsp_sctlist_extension"/>),
-where the OCSP response is provided in the
-<spanx style="verb">certificate_status</spanx> TLS extension (Section 8 of
-<xref target='RFC6066'/>), also known as OCSP stapling. This mechanism is
-already widely (but not universally) implemented. It also allows SCTs to be
-updated on the fly.
-            </t>
-            <t>
-              An X509v3 certificate extension
-(see <xref target="cert_sctlist_extension"/>). This mechanism allows the use of unmodified TLS servers, but the SCTs cannot be updated on the fly. Since the logs that signed the SCTs won't necessarily be accepted by TLS clients for the full lifetime of the certificate, there is a risk that TLS clients will subsequently consider the certificate to be non-compliant and in need of re-issuance.
-            </t>
-          </list>
-        </t>
-        <t>
-          TLS servers SHOULD send SCTs from multiple logs in case one or more
-logs are not acceptable to the TLS client (for example, if a log has been struck
-off for misbehavior, has had a key compromise or is not known to the TLS
-client).
-        </t>
-        <figure>
-          <preamble>
-            Multiple SCTs are combined into an SCT list as follows:
-          </preamble>
-          <artwork>
-    opaque SerializedSCT&lt;1..2^16-1&gt;;
-
-    struct {
-        SerializedSCT sct_list&lt;1..2^16-1&gt;;
-    } SignedCertificateTimestampList;</artwork>
-        </figure>
-        <t>
-          Here, <spanx style="verb">SerializedSCT</spanx> is an opaque
-byte string that contains the serialized SCT structure. This encoding ensures
-that TLS clients can decode each SCT individually (i.e., if there is a version
-upgrade, out-of-date clients can still parse old SCTs while skipping over new
-SCTs whose versions they don't understand).
-        </t>
-        <section title="TLS Extension" anchor="tls_sctlist_extension">
-          <t>
-            One or more SCTs can be sent during the TLS handshake using a TLS
-extension with type <spanx style="verb">signed_certificate_timestamp</spanx>.
-          </t>
-          <t>
-            TLS clients that support the extension SHOULD send a ClientHello
-extension with the appropriate type and empty
-<spanx style="verb">extension_data</spanx>.
-          </t>
-          <t>
-            TLS servers MUST only send SCTs in this TLS extension to TLS clients
-that have indicated support for the extension in the ClientHello, in which case
-the SCTs are sent by setting the <spanx style="verb">extension_data</spanx>
-to a <spanx style="verb">SignedCertificateTimestampList</spanx>.
-          </t>
-          <t>
-            Session resumption uses the original session information: TLS
-clients SHOULD include the extension type in the ClientHello, but if the session
-is resumed, the TLS server is not expected to process it or include the
-extension in the ServerHello.
-          </t>
-        </section>
-        <section title="X.509v3 Extension" anchor="x509v3_extension">
-          <t>
-            One or more SCTs can be embedded in an X.509v3 extension that is
-included in a certificate or an OCSP response. Since RFC5280 requires the
-<spanx style="verb">extnValue</spanx> field (an OCTET STRING) of each X.509v3
-extension to include the DER encoding of an ASN.1 value, we cannot embed a
-<spanx style="verb">SignedCertificateTimestampList</spanx> directly.
-Instead, we have to wrap it inside an additional OCTET STRING (see below),
-which we then put into the <spanx style="verb">extnValue</spanx> field.
-          </t>
-          <section title="OCSP Response Extension" anchor="ocsp_sctlist_extension">
-            <figure>
-              <preamble>
-                A certification authority may embed one or more SCTs in OCSP responses pertaining to the end-entity certificate, by including a non-critical <spanx style="verb">singleExtensions</spanx> extension with OID 1.3.6.1.4.1.11129.2.4.5 whose <spanx style="verb">extnValue</spanx> contains:
-              </preamble>
-              <artwork>
-    CertificateSCTList ::= OCTET STRING</artwork>
-            </figure>
-            <t>
-              <spanx style="verb">CertificateSCTList</spanx> contains a
-<spanx style="verb">SignedCertificateTimestampList</spanx> whose SCTs all have
-the <spanx style="verb">x509_entry</spanx>
-<spanx style="verb">LogEntryType</spanx>.
-            </t>
-          </section>
-          <section title="Certificate Extension" anchor="cert_sctlist_extension">
-            <figure>
-              <preamble>
-                A certification authority that has submitted a precertificate to one or more logs may embed the obtained SCTs in the <spanx style="verb">TBSCertificate</spanx> that will be signed to produce the certificate, by including a non-critical X.509v3 extension with OID 1.3.6.1.4.1.11129.2.4.2 whose <spanx style="verb">extnValue</spanx> contains:
-              </preamble>
-              <artwork>
-    PrecertificateSCTList ::= OCTET STRING</artwork>
-            </figure>
-            <t>
-              <spanx style="verb">PrecertificateSCTList</spanx> contains a
-<spanx style="verb">SignedCertificateTimestampList</spanx> whose SCTs all have
-the <spanx style="verb">precert_entry_V2</spanx>
-<spanx style="verb">LogEntryType</spanx>.
-            </t>
-            <t>
-              Upon receiving the certificate, clients can reconstruct the
-original <spanx style="verb">TBSCertificate</spanx> to verify the SCT
-signatures.
-            </t>
-          </section>
-        </section>
       </section>
       <section title="Merkle Tree" anchor="tree">
         <t>
@@ -1236,6 +1112,133 @@ entry specified by <spanx style="verb">start</spanx>.
       </section>
     </section>
     <section title="TLS Servers">
+      <section title="Including the Signed Certificate Timestamp in the TLS Handshake">
+        <t>
+          TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate. A certificate not accompanied by an SCT (either for the end-entity certificate or for a name-constrained intermediate the end-entity certificate chains to) MUST NOT be considered compliant by TLS clients.
+        </t>
+        <t>
+          The SCT data corresponding to at least one certificate in the chain
+from at least one log must be included in the TLS handshake by using one or more
+of the mechanisms listed below. Three mechanisms are provided because they have
+different tradeoffs. TLS clients MUST implement all three mechanisms. TLS
+servers MUST present SCTs using at least one of the three mechanisms.
+          <list style="symbols">
+            <t>
+              A TLS extension (Section 7.4.1.4 of <xref target='RFC5246'/>) with
+type <spanx style="verb">signed_certificate_timestamp</spanx>
+(see <xref target="tls_sctlist_extension"/>). This mechanism allows TLS servers
+to participate in CT without the cooperation of CAs, unlike the other two
+mechanisms. It also allows SCTs to be updated on the fly.
+            </t>
+            <t>
+              An <xref target='RFC6960'>Online Certificate Status Protocol
+(OCSP)</xref> response extension (see <xref target="ocsp_sctlist_extension"/>),
+where the OCSP response is provided in the
+<spanx style="verb">certificate_status</spanx> TLS extension (Section 8 of
+<xref target='RFC6066'/>), also known as OCSP stapling. This mechanism is
+already widely (but not universally) implemented. It also allows SCTs to be
+updated on the fly.
+            </t>
+            <t>
+              An X509v3 certificate extension
+(see <xref target="cert_sctlist_extension"/>). This mechanism allows the use of unmodified TLS servers, but the SCTs cannot be updated on the fly. Since the logs that signed the SCTs won't necessarily be accepted by TLS clients for the full lifetime of the certificate, there is a risk that TLS clients will subsequently consider the certificate to be non-compliant and in need of re-issuance.
+            </t>
+          </list>
+        </t>
+        <t>
+          TLS servers SHOULD send SCTs from multiple logs in case one or more
+logs are not acceptable to the TLS client (for example, if a log has been struck
+off for misbehavior, has had a key compromise or is not known to the TLS
+client).
+        </t>
+        <figure>
+          <preamble>
+            Multiple SCTs are combined into an SCT list as follows:
+          </preamble>
+          <artwork>
+    opaque SerializedSCT&lt;1..2^16-1&gt;;
+
+    struct {
+        SerializedSCT sct_list&lt;1..2^16-1&gt;;
+    } SignedCertificateTimestampList;</artwork>
+        </figure>
+        <t>
+          Here, <spanx style="verb">SerializedSCT</spanx> is an opaque
+byte string that contains the serialized SCT structure. This encoding ensures
+that TLS clients can decode each SCT individually (i.e., if there is a version
+upgrade, out-of-date clients can still parse old SCTs while skipping over new
+SCTs whose versions they don't understand).
+        </t>
+        <section title="TLS Extension" anchor="tls_sctlist_extension">
+          <t>
+            One or more SCTs can be sent during the TLS handshake using a TLS
+extension with type <spanx style="verb">signed_certificate_timestamp</spanx>.
+          </t>
+          <t>
+            TLS clients that support the extension SHOULD send a ClientHello
+extension with the appropriate type and empty
+<spanx style="verb">extension_data</spanx>.
+          </t>
+          <t>
+            TLS servers MUST only send SCTs in this TLS extension to TLS clients
+that have indicated support for the extension in the ClientHello, in which case
+the SCTs are sent by setting the <spanx style="verb">extension_data</spanx>
+to a <spanx style="verb">SignedCertificateTimestampList</spanx>.
+          </t>
+          <t>
+            Session resumption uses the original session information: TLS
+clients SHOULD include the extension type in the ClientHello, but if the session
+is resumed, the TLS server is not expected to process it or include the
+extension in the ServerHello.
+          </t>
+        </section>
+        <section title="X.509v3 Extension" anchor="x509v3_extension">
+          <t>
+            One or more SCTs can be embedded in an X.509v3 extension that is
+included in a certificate or an OCSP response. Since RFC5280 requires the
+<spanx style="verb">extnValue</spanx> field (an OCTET STRING) of each X.509v3
+extension to include the DER encoding of an ASN.1 value, we cannot embed a
+<spanx style="verb">SignedCertificateTimestampList</spanx> directly.
+Instead, we have to wrap it inside an additional OCTET STRING (see below),
+which we then put into the <spanx style="verb">extnValue</spanx> field.
+          </t>
+          <section title="OCSP Response Extension" anchor="ocsp_sctlist_extension">
+            <figure>
+              <preamble>
+                A certification authority may embed one or more SCTs in OCSP responses pertaining to the end-entity certificate, by including a non-critical <spanx style="verb">singleExtensions</spanx> extension with OID 1.3.6.1.4.1.11129.2.4.5 whose <spanx style="verb">extnValue</spanx> contains:
+              </preamble>
+              <artwork>
+    CertificateSCTList ::= OCTET STRING</artwork>
+            </figure>
+            <t>
+              <spanx style="verb">CertificateSCTList</spanx> contains a
+<spanx style="verb">SignedCertificateTimestampList</spanx> whose SCTs all have
+the <spanx style="verb">x509_entry</spanx>
+<spanx style="verb">LogEntryType</spanx>.
+            </t>
+          </section>
+          <section title="Certificate Extension" anchor="cert_sctlist_extension">
+            <figure>
+              <preamble>
+                A certification authority that has submitted a precertificate to one or more logs may embed the obtained SCTs in the <spanx style="verb">TBSCertificate</spanx> that will be signed to produce the certificate, by including a non-critical X.509v3 extension with OID 1.3.6.1.4.1.11129.2.4.2 whose <spanx style="verb">extnValue</spanx> contains:
+              </preamble>
+              <artwork>
+    PrecertificateSCTList ::= OCTET STRING</artwork>
+            </figure>
+            <t>
+              <spanx style="verb">PrecertificateSCTList</spanx> contains a
+<spanx style="verb">SignedCertificateTimestampList</spanx> whose SCTs all have
+the <spanx style="verb">precert_entry_V2</spanx>
+<spanx style="verb">LogEntryType</spanx>.
+            </t>
+            <t>
+              Upon receiving the certificate, clients can reconstruct the
+original <spanx style="verb">TBSCertificate</spanx> to verify the SCT
+signatures.
+            </t>
+          </section>
+        </section>
+      </section>
     </section>
     <section title="Clients">
       <t>

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -319,11 +319,10 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
       </section>
       <section title="Precertificates">
         <t>
-          Alternatively, (root as well as intermediate) certification authorities
-may preannounce a certificate to logs prior to issuance in order to incorporate
-the SCT in the issued certificate. To do this, the CA submits a precertificate
-that the log can use to create an entry that will be valid against the issued
-certificate. A precertificate is a CMS <xref target="RFC5652"/>
+          Alternatively, (root as well as intermediate) CAs may preannounce a certificate prior to issuance by <xref target="add_pre_chain">submitting a precertificate</xref> that the log can use to create an entry that will be valid against the issued certificate. The CA MAY incorporate the returned SCT in the issued certificate.
+        </t>
+        <t>
+          A precertificate is a CMS <xref target="RFC5652"/>
 <spanx style="verb">signed-data</spanx> object that contains a TBSCertificate
 <xref target="RFC5280"/> in its
 <spanx style="verb">SignedData.encapContentInfo.eContent</spanx> field,
@@ -985,7 +984,7 @@ messages.
         </t>
       </section>
 
-      <section title="Add PreCertChain to Log">
+      <section title="Add PreCertChain to Log" anchor="add_pre_chain">
         <t>
           POST https://&lt;log server&gt;/ct/v2/add-pre-chain
         </t>

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -310,7 +310,7 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
         Submitters submit certificates or precertificates to logs for public auditing, as described below. In order to enable attribution of each logged certificate or precertificate to its issuer, each submission MUST be accompanied by all additional certificates required to verify the chain up to an accepted root certificate. The root certificate itself MAY be omitted from the submission.
       </t>
       <t>
-        When a valid certificate is submitted to a log, the log MUST return a Signed Certificate Timestamp (SCT). When a Submitter intends to use the returned SCT directly in a TLS handshake or to construct a certificate, they SHOULD validate the SCT as described in <xref target="tls_clients"/> if they understand its format.
+        If a log accepts a submission, it will return a Signed Certificate Timestamp (SCT). The submitter SHOULD validate the returned SCT as described in <xref target="tls_clients"/> if they understand its format and they intend to use it directly in a TLS handshake or to construct a certificate.
       </t>
     </section>
     <section title="Log Format and Operation">

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -310,7 +310,7 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
         Submitters submit certificates or precertificates to logs for public auditing, as described below. In order to enable attribution of each logged certificate or precertificate to its issuer, each submission MUST be accompanied by all additional certificates required to verify the chain up to an accepted root certificate. The root certificate itself MAY be omitted from the submission.
       </t>
       <t>
-        When a Submitter intends to use the returned SCT directly in a TLS handshake or to construct a certificate, they SHOULD validate the SCT as described in <xref target="tls_clients"/> if they understand its format.
+        When a valid certificate is submitted to a log, the log MUST return a Signed Certificate Timestamp (SCT). When a Submitter intends to use the returned SCT directly in a TLS handshake or to construct a certificate, they SHOULD validate the SCT as described in <xref target="tls_clients"/> if they understand its format.
       </t>
     </section>
     <section title="Log Format and Operation">
@@ -321,7 +321,7 @@ it is expected that certificate owners or their CAs will usually submit them. A
 log is a single, append-only Merkle Tree of such certificates.
       </t>
       <t>
-        When a valid certificate is submitted to a log, the log MUST return a Signed Certificate Timestamp (SCT). The SCT is the log's promise to incorporate the certificate in the Merkle Tree within a fixed amount of time known as the Maximum Merge Delay (MMD). If the log has previously seen the certificate, it MAY return the same SCT as it returned before (note that if a certificate was previously logged as a precertificate, then the precertificate's SCT would not be appropriate, instead a fresh SCT of type x509_entry should be generated). TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate. A certificate not accompanied by an SCT (either for the end-entity certificate or for a name-constrained intermediate the end-entity certificate chains to) MUST NOT be considered compliant by TLS clients.
+         The SCT is the log's promise to incorporate the certificate in the Merkle Tree within a fixed amount of time known as the Maximum Merge Delay (MMD). If the log has previously seen the certificate, it MAY return the same SCT as it returned before (note that if a certificate was previously logged as a precertificate, then the precertificate's SCT would not be appropriate, instead a fresh SCT of type x509_entry should be generated). TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate. A certificate not accompanied by an SCT (either for the end-entity certificate or for a name-constrained intermediate the end-entity certificate chains to) MUST NOT be considered compliant by TLS clients.
       </t>
       <t>
         Periodically, each log appends all its new entries to the Merkle Tree and signs the root of the tree. The log MUST incorporate a certificate in its Merkle Tree within the Maximum Merge Delay period after the issuance of the SCT. When encountering an SCT, an Auditor can verify that the certificate was added to the Merkle Tree within that timeframe.

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -307,7 +307,10 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
     </section>
     <section title="Submitters">
       <t>
-        Submitters submit certificates or precertificates to logs for public auditing, as described below. When a Submitter intends to use the returned SCT directly in a TLS handshake or to construct a certificate, they SHOULD validate the SCT as described in <xref target="tls_clients"/> if they understand its format.
+        Submitters submit certificates or precertificates to logs for public auditing, as described below. In order to enable attribution of each logged certificate to its issuer, each submitted certificate MUST be accompanied by all additional certificates required to verify the certificate chain up to an accepted root certificate. The root certificate itself MAY be omitted from the chain submitted to the log server.
+      </t>
+      <t>
+        When a Submitter intends to use the returned SCT directly in a TLS handshake or to construct a certificate, they SHOULD validate the SCT as described in <xref target="tls_clients"/> if they understand its format.
       </t>
     </section>
     <section title="Log Format and Operation">
@@ -328,7 +331,7 @@ log is a single, append-only Merkle Tree of such certificates.
       </t>
       <section title="Log Entries">
         <t>
-          In order to enable attribution of each logged certificate to its issuer, each submitted certificate MUST be accompanied by all additional certificates required to verify the certificate chain up to an accepted root certificate. The root certificate itself MAY be omitted from the chain submitted to the log server. The log SHALL allow retrieval of a list of accepted root certificates (this list might usefully be the union of root certificates trusted by major browser vendors).
+          The log SHALL allow retrieval of a list of accepted root certificates (this list might usefully be the union of root certificates trusted by major browser vendors).
         </t>
         <t>
           Alternatively, (root as well as intermediate) certification authorities

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -313,16 +313,18 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
         If a log accepts a submission, it will return a Signed Certificate Timestamp (SCT). The submitter SHOULD validate the returned SCT as described in <xref target="tls_clients"/> if they understand its format and they intend to use it directly in a TLS handshake or to construct a certificate.
       </t>
       <section title="Certificates">
+        <t>
+          Anyone can submit certificates to certificate logs;
+however, since certificates will not be accepted by TLS clients unless logged,
+it is expected that certificate owners or their CAs will usually submit them.
+        </t>
       </section>
       <section title="Precertificates">
       </section>
     </section>
     <section title="Log Format and Operation">
       <t>
-        Anyone can submit certificates to certificate logs;
-however, since certificates will not be accepted by TLS clients unless logged,
-it is expected that certificate owners or their CAs will usually submit them. A
-log is a single, append-only Merkle Tree of such certificates.
+        A log is a single, append-only Merkle Tree of such certificates.
       </t>
       <t>
          The SCT is the log's promise to incorporate the certificate in the Merkle Tree within a fixed amount of time known as the Maximum Merge Delay (MMD). If the log has previously seen the certificate, it MAY return the same SCT as it returned before (note that if a certificate was previously logged as a precertificate, then the precertificate's SCT would not be appropriate, instead a fresh SCT of type x509_entry should be generated). TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate. A certificate not accompanied by an SCT (either for the end-entity certificate or for a name-constrained intermediate the end-entity certificate chains to) MUST NOT be considered compliant by TLS clients.

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -1111,12 +1111,12 @@ entry specified by <spanx style="verb">start</spanx>.
         </t>
       </section>
     </section>
-    <section title="TLS Servers">
+    <section title="TLS Servers" anchor="tls_servers">
       <t>
         TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate.
       </t>
       <t>
-        The SCT data corresponding to at least one certificate in the chain from at least one log must be included in the TLS handshake by using one or more of the mechanisms listed below. Three mechanisms are provided because they have different tradeoffs. TLS clients MUST implement all three mechanisms. TLS servers MUST present SCTs using at least one of the three mechanisms.
+        The SCT data corresponding to at least one certificate in the chain from at least one log must be included in the TLS handshake by using one or more of the mechanisms listed below. Three mechanisms are provided because they have different tradeoffs. TLS servers MUST present SCTs using at least one of the three mechanisms.
         <list style="symbols">
           <t>
             A TLS extension (Section 7.4.1.4 of <xref target='RFC5246'/>) with type <spanx style="verb">signed_certificate_timestamp</spanx> (see <xref target="tls_sctlist_extension"/>). This mechanism allows TLS servers to participate in CT without the cooperation of CAs, unlike the other two mechanisms. It also allows SCTs to be updated on the fly.
@@ -1251,7 +1251,10 @@ but it is expected there will be a variety.
       </section>
       <section title="TLS Client" anchor="tls_clients">
         <t>
-          TLS clients receive SCTs alongside or in certificates, either for the server certificate itself or for a name-constrained intermediate the server certificate chains to. In addition to normal validation of the certificate and its chain, TLS clients SHOULD validate the SCT by computing the signature input from the SCT data as well as the certificate and verifying the signature, using the corresponding log's public key. By validating SCTs, TLS clients can thus determine whether certificates are compliant. A certificate not accompanied by a valid SCT MUST NOT be considered compliant by TLS clients. However, specifying the TLS clients' behavior once compliance or non-compliance has been determined (for example, whether a certificate should be rejected due to the lack of valid SCTs) is outside the scope of this document.
+          TLS clients receive SCTs alongside or in certificates, either for the server certificate itself or for a name-constrained intermediate the server certificate chains to. TLS clients MUST implement all of the three mechanisms by which TLS servers may present SCTs (see <xref target="tls_servers"/>).
+        </t>
+        <t>
+          In addition to normal validation of the certificate and its chain, TLS clients SHOULD validate the SCT by computing the signature input from the SCT data as well as the certificate and verifying the signature, using the corresponding log's public key. By validating SCTs, TLS clients can thus determine whether certificates are compliant. A certificate not accompanied by a valid SCT MUST NOT be considered compliant by TLS clients. However, specifying the TLS clients' behavior once compliance or non-compliance has been determined (for example, whether a certificate should be rejected due to the lack of valid SCTs) is outside the scope of this document.
         </t>
         <t>
           A TLS client MAY audit the corresponding log by requesting, and

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -318,25 +318,6 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
         </t>
       </section>
       <section title="Precertificates">
-      </section>
-    </section>
-    <section title="Log Format and Operation">
-      <t>
-        A log is a single, append-only Merkle Tree of such certificates.
-      </t>
-      <t>
-         The SCT is the log's promise to incorporate the certificate in the Merkle Tree within a fixed amount of time known as the Maximum Merge Delay (MMD). If the log has previously seen the certificate, it MAY return the same SCT as it returned before (note that if a certificate was previously logged as a precertificate, then the precertificate's SCT would not be appropriate, instead a fresh SCT of type x509_entry should be generated). TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate. A certificate not accompanied by an SCT (either for the end-entity certificate or for a name-constrained intermediate the end-entity certificate chains to) MUST NOT be considered compliant by TLS clients.
-      </t>
-      <t>
-        Periodically, each log appends all its new entries to the Merkle Tree and signs the root of the tree. The log MUST incorporate a certificate in its Merkle Tree within the Maximum Merge Delay period after the issuance of the SCT. When encountering an SCT, an Auditor can verify that the certificate was added to the Merkle Tree within that timeframe.
-      </t>
-      <t>
-        Log operators MUST NOT impose any conditions on retrieving or sharing data from the log.
-      </t>
-      <section title="Log Entries">
-        <t>
-          The log SHALL allow retrieval of a list of accepted root certificates (this list might usefully be the union of root certificates trusted by major browser vendors).
-        </t>
         <t>
           Alternatively, (root as well as intermediate) certification authorities
 may preannounce a certificate to logs prior to issuance in order to incorporate
@@ -365,6 +346,25 @@ be omitted.
         </t>
         <t>
           The CMS object MUST be DER encoded. Note that, because of the structure of CMS, the signature on the CMS object will not be a valid X.509v3 signature and so cannot be used to construct a certificate from the precertificate.
+        </t>
+      </section>
+    </section>
+    <section title="Log Format and Operation">
+      <t>
+        A log is a single, append-only Merkle Tree of such certificates.
+      </t>
+      <t>
+        The SCT is the log's promise to incorporate the certificate in the Merkle Tree within a fixed amount of time known as the Maximum Merge Delay (MMD). If the log has previously seen the certificate, it MAY return the same SCT as it returned before (note that if a certificate was previously logged as a precertificate, then the precertificate's SCT would not be appropriate, instead a fresh SCT of type x509_entry should be generated). TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate. A certificate not accompanied by an SCT (either for the end-entity certificate or for a name-constrained intermediate the end-entity certificate chains to) MUST NOT be considered compliant by TLS clients.
+      </t>
+      <t>
+        Periodically, each log appends all its new entries to the Merkle Tree and signs the root of the tree. The log MUST incorporate a certificate in its Merkle Tree within the Maximum Merge Delay period after the issuance of the SCT. When encountering an SCT, an Auditor can verify that the certificate was added to the Merkle Tree within that timeframe.
+      </t>
+      <t>
+        Log operators MUST NOT impose any conditions on retrieving or sharing data from the log.
+      </t>
+      <section title="Log Entries">
+        <t>
+          The log SHALL allow retrieval of a list of accepted root certificates (this list might usefully be the union of root certificates trusted by major browser vendors).
         </t>
         <t>
           Logs MUST verify that the submitted certificate or precertificate has

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -307,12 +307,12 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
     </section>
     <section title="Submitters">
       <t>
-        Submitters submit certificates or precertificates to the log as described above. When a Submitter intends to use the returned SCT directly in a TLS handshake or to construct a certificate, they SHOULD validate the SCT as described in <xref target="tls_clients"/> if they understand its format.
+        Submitters submit certificates or precertificates to logs for public auditing, as described below. When a Submitter intends to use the returned SCT directly in a TLS handshake or to construct a certificate, they SHOULD validate the SCT as described in <xref target="tls_clients"/> if they understand its format.
       </t>
     </section>
     <section title="Log Format and Operation">
       <t>
-        Anyone can submit certificates to certificate logs for public auditing;
+        Anyone can submit certificates to certificate logs;
 however, since certificates will not be accepted by TLS clients unless logged,
 it is expected that certificate owners or their CAs will usually submit them. A
 log is a single, append-only Merkle Tree of such certificates.

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -317,7 +317,7 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
           Anyone can <xref target="add-chain">submit a certificate</xref> to a log. Since certificates may not be accepted by TLS clients unless logged, it is expected that certificate owners or their CAs will usually submit them.
         </t>
       </section>
-      <section title="Precertificates">
+      <section title="Precertificates" anchor="Precertificates">
         <t>
           Alternatively, (root as well as intermediate) CAs may preannounce a certificate prior to issuance by <xref target="add-pre-chain">submitting a precertificate</xref> that the log can use to create an entry that will be valid against the issued certificate. The CA MAY incorporate the returned SCT in the issued certificate.
         </t>
@@ -421,27 +421,24 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
       <t>
         When it receives a valid submission, the log MUST return an SCT that corresponds to the submitted certificate or precertificate. If the log has previously seen this valid submission, it MAY return the same SCT as it returned before (note that if a certificate was previously logged as a precertificate, then the precertificate's SCT would not be appropriate, instead a fresh SCT of type x509_entry should be generated).
       </t>
+      <t>
         An SCT is the log's promise to incorporate the submitted entry in its Merkle Tree no later than a fixed amount of time, known as the Maximum Merge Delay (MMD), after the issuance of the SCT. Periodically, the log MUST append all its new entries to its Merkle Tree and sign the root of the tree. This provides auditable evidence that the log kept all its promises.
       </t>
       <t>
         Log operators MUST NOT impose any conditions on retrieving or sharing data from the log.
       </t>
+      <section title="Accepting Submissions">
+        <t>
+          Logs MUST verify that each submitted certificate or precertificate has a valid signature chain to an accepted root certificate, using the chain of intermediate CA certificates provided by the submitter. Logs MUST accept certificates and precertificates that are fully valid according to <xref target="RFC5280">RFC 5280</xref> verification rules and are submitted with such a chain. Logs MAY accept certificates and precertificates that have expired, are not yet valid, have been revoked, or are otherwise not fully valid according to RFC 5280 verification rules in order to accommodate quirks of CA certificate-issuing software. However, logs MUST reject submissions without a valid signature chain to an accepted root certificate. Logs MUST also reject precertificates that do not conform to the requirements in <xref target="Precertificates"/>.
+        </t>
+        <t>
+          Logs SHOULD limit the length of chain they will accept. The maximum chain length is specified in the log's metadata.
+        </t>
+        <t>
+          The log SHALL allow retrieval of its list of accepted root certificates (see <xref target="get-roots"/>). This list might usefully be the union of root certificates trusted by major browser vendors.
+        </t>
+      </section>
       <section title="Log Entries">
-        <t>
-          The log SHALL allow retrieval of a list of accepted root certificates (this list might usefully be the union of root certificates trusted by major browser vendors).
-        </t>
-        <t>
-          Logs MUST verify that the submitted certificate or precertificate has
-a valid signature chain to an accepted root certificate, using the chain of
-intermediate CA certificates provided by the submitter. Logs MUST accept
-certificates that are fully valid according to <xref target="RFC5280">RFC 5280</xref> verification rules
-and are submitted with such a chain. Logs MAY accept
-certificates and precertificates that have expired, are not yet valid, have been
-revoked, or are otherwise not fully valid according to RFC 5280 verification rules
-in order to accommodate quirks of CA certificate-issuing software. However, logs
-MUST reject certificates without a valid signature chain to an accepted root
-certificate. Logs MUST also reject precertificates that are not valid DER encoded CMS <spanx style="verb">signed-data</spanx> objects.
-        </t>
         <t>
           If a certificate is accepted and an SCT issued, the accepting log MUST store the entire chain used for verification. This chain MUST include the certificate or precertificate itself, the zero or more intermediate CA certificates provided by the submitter, and the root certificate used to verify the chain (even if it was omitted from the submission). The log MUST present this chain for auditing upon request. This chain is required to prevent a CA from avoiding blame by logging a partial or empty chain.
         </t>
@@ -468,9 +465,6 @@ certificate. Logs MUST also reject precertificates that are not valid DER encode
         ASN.1Cert precertificate_chain&lt;0..2^24-1&gt;;
     } PrecertChainEntryV2;</artwork>
         </figure>
-        <t>
-          Logs SHOULD limit the length of chain they will accept. The maximum chain length is specified in the log's metadata.
-        </t>
         <t>
           <spanx style="verb">entry_type</spanx> is the type of this entry. Future revisions of this protocol may add new LogEntryType values. <xref target="client_messages"/> explains how clients should handle unknown entry types.
         </t>
@@ -1087,7 +1081,7 @@ entry specified by <spanx style="verb">start</spanx>.
         <t>See <xref target="verify_hash" /> for an outline of how to use a complete list of <spanx style="verb">leaf_input</spanx> entries to verify the <spanx style="verb">root_hash</spanx>.</t>
       </section>
 
-      <section title="Retrieve Accepted Root Certificates">
+      <section title="Retrieve Accepted Root Certificates" anchor="get-roots">
         <t>
           GET https://&lt;log server&gt;/ct/v1/get-roots
         </t>

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -1254,15 +1254,15 @@ but it is expected there will be a variety.
           TLS clients receive SCTs alongside or in certificates, either for the server certificate itself or for a name-constrained intermediate the server certificate chains to. TLS clients MUST implement all of the three mechanisms by which TLS servers may present SCTs (see <xref target="tls_servers"/>).
         </t>
         <t>
-          In addition to normal validation of the certificate and its chain, TLS clients SHOULD validate the SCT by computing the signature input from the SCT data as well as the certificate and verifying the signature, using the corresponding log's public key. By validating SCTs, TLS clients can thus determine whether certificates are compliant. A certificate not accompanied by a valid SCT MUST NOT be considered compliant by TLS clients. However, specifying the TLS clients' behavior once compliance or non-compliance has been determined (for example, whether a certificate should be rejected due to the lack of valid SCTs) is outside the scope of this document.
+          In addition to normal validation of the certificate and its chain, TLS clients SHOULD validate each SCT by computing the signature input from the SCT data as well as the certificate and verifying the signature, using the corresponding log's public key. TLS clients MUST reject SCTs whose timestamp is in the future.
+        </t>
+        <t>
+          By validating SCTs, TLS clients can thus determine whether certificates are compliant. A certificate not accompanied by a valid SCT MUST NOT be considered compliant by TLS clients. However, specifying the TLS clients' behavior once compliance or non-compliance has been determined (for example, whether a certificate should be rejected due to the lack of valid SCTs) is outside the scope of this document.
         </t>
         <t>
           A TLS client MAY audit the corresponding log by requesting, and
           verifying, a Merkle audit proof for said certificate.
           If the TLS client holds an STH that predates the SCT, it MAY, in the process of auditing, request a new STH from the log (<xref target="fetch_sth"/>), then verify it by requesting a consistency proof (<xref target="fetch_consistency"/>).
-        </t>
-        <t>
-          TLS clients MUST reject SCTs whose timestamp is in the future.
         </t>
       </section>
       <section title="Monitor" anchor="monitor">

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -1113,10 +1113,7 @@ entry specified by <spanx style="verb">start</spanx>.
     </section>
     <section title="TLS Servers" anchor="tls_servers">
       <t>
-        TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate.
-      </t>
-      <t>
-        The SCT data corresponding to at least one certificate in the chain from at least one log must be included in the TLS handshake by using one or more of the mechanisms listed below. Three mechanisms are provided because they have different tradeoffs. TLS servers MUST present SCTs using at least one of the three mechanisms.
+        TLS servers MUST use at least one of the three mechanisms listed below to present one or more SCTs from one or more logs to each TLS client during TLS handshakes, where each SCT corresponds to the server certificate or to a name-constrained intermediate the server certificate chains to. Three mechanisms are provided because they have different tradeoffs.
         <list style="symbols">
           <t>
             A TLS extension (Section 7.4.1.4 of <xref target='RFC5246'/>) with type <spanx style="verb">signed_certificate_timestamp</spanx> (see <xref target="tls_sctlist_extension"/>). This mechanism allows TLS servers to participate in CT without the cooperation of CAs, unlike the other two mechanisms. It also allows SCTs to be updated on the fly.

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -1112,131 +1112,84 @@ entry specified by <spanx style="verb">start</spanx>.
       </section>
     </section>
     <section title="TLS Servers">
-      <section title="Including the Signed Certificate Timestamp in the TLS Handshake">
-        <t>
-          TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate. A certificate not accompanied by an SCT (either for the end-entity certificate or for a name-constrained intermediate the end-entity certificate chains to) MUST NOT be considered compliant by TLS clients.
-        </t>
-        <t>
-          The SCT data corresponding to at least one certificate in the chain
-from at least one log must be included in the TLS handshake by using one or more
-of the mechanisms listed below. Three mechanisms are provided because they have
-different tradeoffs. TLS clients MUST implement all three mechanisms. TLS
-servers MUST present SCTs using at least one of the three mechanisms.
-          <list style="symbols">
-            <t>
-              A TLS extension (Section 7.4.1.4 of <xref target='RFC5246'/>) with
-type <spanx style="verb">signed_certificate_timestamp</spanx>
-(see <xref target="tls_sctlist_extension"/>). This mechanism allows TLS servers
-to participate in CT without the cooperation of CAs, unlike the other two
-mechanisms. It also allows SCTs to be updated on the fly.
-            </t>
-            <t>
-              An <xref target='RFC6960'>Online Certificate Status Protocol
-(OCSP)</xref> response extension (see <xref target="ocsp_sctlist_extension"/>),
-where the OCSP response is provided in the
-<spanx style="verb">certificate_status</spanx> TLS extension (Section 8 of
-<xref target='RFC6066'/>), also known as OCSP stapling. This mechanism is
-already widely (but not universally) implemented. It also allows SCTs to be
-updated on the fly.
-            </t>
-            <t>
-              An X509v3 certificate extension
-(see <xref target="cert_sctlist_extension"/>). This mechanism allows the use of unmodified TLS servers, but the SCTs cannot be updated on the fly. Since the logs that signed the SCTs won't necessarily be accepted by TLS clients for the full lifetime of the certificate, there is a risk that TLS clients will subsequently consider the certificate to be non-compliant and in need of re-issuance.
-            </t>
-          </list>
-        </t>
-        <t>
-          TLS servers SHOULD send SCTs from multiple logs in case one or more
-logs are not acceptable to the TLS client (for example, if a log has been struck
-off for misbehavior, has had a key compromise or is not known to the TLS
-client).
-        </t>
-        <figure>
-          <preamble>
-            Multiple SCTs are combined into an SCT list as follows:
-          </preamble>
-          <artwork>
+      <t>
+        TLS servers MUST present an SCT from one or more logs to the TLS client together with the certificate. A certificate not accompanied by an SCT (either for the end-entity certificate or for a name-constrained intermediate the end-entity certificate chains to) MUST NOT be considered compliant by TLS clients.
+      </t>
+      <t>
+        The SCT data corresponding to at least one certificate in the chain from at least one log must be included in the TLS handshake by using one or more of the mechanisms listed below. Three mechanisms are provided because they have different tradeoffs. TLS clients MUST implement all three mechanisms. TLS servers MUST present SCTs using at least one of the three mechanisms.
+        <list style="symbols">
+          <t>
+            A TLS extension (Section 7.4.1.4 of <xref target='RFC5246'/>) with type <spanx style="verb">signed_certificate_timestamp</spanx> (see <xref target="tls_sctlist_extension"/>). This mechanism allows TLS servers to participate in CT without the cooperation of CAs, unlike the other two mechanisms. It also allows SCTs to be updated on the fly.
+          </t>
+          <t>
+            An <xref target='RFC6960'>Online Certificate Status Protocol (OCSP)</xref> response extension (see <xref target="ocsp_sctlist_extension"/>), where the OCSP response is provided in the <spanx style="verb">certificate_status</spanx> TLS extension (Section 8 of <xref target='RFC6066'/>), also known as OCSP stapling. This mechanism is already widely (but not universally) implemented. It also allows SCTs to be updated on the fly.
+          </t>
+          <t>
+            An X509v3 certificate extension (see <xref target="cert_sctlist_extension"/>). This mechanism allows the use of unmodified TLS servers, but the SCTs cannot be updated on the fly. Since the logs that signed the SCTs won't necessarily be accepted by TLS clients for the full lifetime of the certificate, there is a risk that TLS clients will subsequently consider the certificate to be non-compliant and in need of re-issuance.
+          </t>
+        </list>
+      </t>
+      <t>
+        TLS servers SHOULD send SCTs from multiple logs in case one or more logs are not acceptable to the TLS client (for example, if a log has been struck off for misbehavior, has had a key compromise or is not known to the TLS client).
+      </t>
+      <figure>
+        <preamble>
+          Multiple SCTs are combined into an SCT list as follows:
+        </preamble>
+        <artwork>
     opaque SerializedSCT&lt;1..2^16-1&gt;;
 
     struct {
         SerializedSCT sct_list&lt;1..2^16-1&gt;;
     } SignedCertificateTimestampList;</artwork>
-        </figure>
+      </figure>
+      <t>
+        Here, <spanx style="verb">SerializedSCT</spanx> is an opaque byte string that contains the serialized SCT structure. This encoding ensures that TLS clients can decode each SCT individually (i.e., if there is a version upgrade, out-of-date clients can still parse old SCTs while skipping over new SCTs whose versions they don't understand).
+      </t>
+      <section title="TLS Extension" anchor="tls_sctlist_extension">
         <t>
-          Here, <spanx style="verb">SerializedSCT</spanx> is an opaque
-byte string that contains the serialized SCT structure. This encoding ensures
-that TLS clients can decode each SCT individually (i.e., if there is a version
-upgrade, out-of-date clients can still parse old SCTs while skipping over new
-SCTs whose versions they don't understand).
+          One or more SCTs can be sent during the TLS handshake using a TLS extension with type <spanx style="verb">signed_certificate_timestamp</spanx>.
         </t>
-        <section title="TLS Extension" anchor="tls_sctlist_extension">
+        <t>
+          TLS clients that support the extension SHOULD send a ClientHello extension with the appropriate type and empty <spanx style="verb">extension_data</spanx>.
+        </t>
+        <t>
+          TLS servers MUST only send SCTs in this TLS extension to TLS clients that have indicated support for the extension in the ClientHello, in which case the SCTs are sent by setting the <spanx style="verb">extension_data</spanx> to a <spanx style="verb">SignedCertificateTimestampList</spanx>.
+        </t>
+        <t>
+          Session resumption uses the original session information: TLS clients SHOULD include the extension type in the ClientHello, but if the session is resumed, the TLS server is not expected to process it or include the extension in the ServerHello.
+        </t>
+      </section>
+      <section title="X.509v3 Extension" anchor="x509v3_extension">
+        <t>
+          One or more SCTs can be embedded in an X.509v3 extension that is included in a certificate or an OCSP response. Since RFC5280 requires the <spanx style="verb">extnValue</spanx> field (an OCTET STRING) of each X.509v3 extension to include the DER encoding of an ASN.1 value, we cannot embed a <spanx style="verb">SignedCertificateTimestampList</spanx> directly. Instead, we have to wrap it inside an additional OCTET STRING (see below), which we then put into the <spanx style="verb">extnValue</spanx> field.
+        </t>
+        <section title="OCSP Response Extension" anchor="ocsp_sctlist_extension">
+          <figure>
+            <preamble>
+              A certification authority may embed one or more SCTs in OCSP responses pertaining to the end-entity certificate, by including a non-critical <spanx style="verb">singleExtensions</spanx> extension with OID 1.3.6.1.4.1.11129.2.4.5 whose <spanx style="verb">extnValue</spanx> contains:
+            </preamble>
+            <artwork>
+    CertificateSCTList ::= OCTET STRING</artwork>
+          </figure>
           <t>
-            One or more SCTs can be sent during the TLS handshake using a TLS
-extension with type <spanx style="verb">signed_certificate_timestamp</spanx>.
-          </t>
-          <t>
-            TLS clients that support the extension SHOULD send a ClientHello
-extension with the appropriate type and empty
-<spanx style="verb">extension_data</spanx>.
-          </t>
-          <t>
-            TLS servers MUST only send SCTs in this TLS extension to TLS clients
-that have indicated support for the extension in the ClientHello, in which case
-the SCTs are sent by setting the <spanx style="verb">extension_data</spanx>
-to a <spanx style="verb">SignedCertificateTimestampList</spanx>.
-          </t>
-          <t>
-            Session resumption uses the original session information: TLS
-clients SHOULD include the extension type in the ClientHello, but if the session
-is resumed, the TLS server is not expected to process it or include the
-extension in the ServerHello.
+            <spanx style="verb">CertificateSCTList</spanx> contains a <spanx style="verb">SignedCertificateTimestampList</spanx> whose SCTs all have the <spanx style="verb">x509_entry</spanx> <spanx style="verb">LogEntryType</spanx>.
           </t>
         </section>
-        <section title="X.509v3 Extension" anchor="x509v3_extension">
-          <t>
-            One or more SCTs can be embedded in an X.509v3 extension that is
-included in a certificate or an OCSP response. Since RFC5280 requires the
-<spanx style="verb">extnValue</spanx> field (an OCTET STRING) of each X.509v3
-extension to include the DER encoding of an ASN.1 value, we cannot embed a
-<spanx style="verb">SignedCertificateTimestampList</spanx> directly.
-Instead, we have to wrap it inside an additional OCTET STRING (see below),
-which we then put into the <spanx style="verb">extnValue</spanx> field.
-          </t>
-          <section title="OCSP Response Extension" anchor="ocsp_sctlist_extension">
-            <figure>
-              <preamble>
-                A certification authority may embed one or more SCTs in OCSP responses pertaining to the end-entity certificate, by including a non-critical <spanx style="verb">singleExtensions</spanx> extension with OID 1.3.6.1.4.1.11129.2.4.5 whose <spanx style="verb">extnValue</spanx> contains:
-              </preamble>
-              <artwork>
-    CertificateSCTList ::= OCTET STRING</artwork>
-            </figure>
-            <t>
-              <spanx style="verb">CertificateSCTList</spanx> contains a
-<spanx style="verb">SignedCertificateTimestampList</spanx> whose SCTs all have
-the <spanx style="verb">x509_entry</spanx>
-<spanx style="verb">LogEntryType</spanx>.
-            </t>
-          </section>
-          <section title="Certificate Extension" anchor="cert_sctlist_extension">
-            <figure>
-              <preamble>
-                A certification authority that has submitted a precertificate to one or more logs may embed the obtained SCTs in the <spanx style="verb">TBSCertificate</spanx> that will be signed to produce the certificate, by including a non-critical X.509v3 extension with OID 1.3.6.1.4.1.11129.2.4.2 whose <spanx style="verb">extnValue</spanx> contains:
-              </preamble>
-              <artwork>
+        <section title="Certificate Extension" anchor="cert_sctlist_extension">
+          <figure>
+            <preamble>
+              A certification authority that has submitted a precertificate to one or more logs may embed the obtained SCTs in the <spanx style="verb">TBSCertificate</spanx> that will be signed to produce the certificate, by including a non-critical X.509v3 extension with OID 1.3.6.1.4.1.11129.2.4.2 whose <spanx style="verb">extnValue</spanx> contains:
+            </preamble>
+            <artwork>
     PrecertificateSCTList ::= OCTET STRING</artwork>
-            </figure>
-            <t>
-              <spanx style="verb">PrecertificateSCTList</spanx> contains a
-<spanx style="verb">SignedCertificateTimestampList</spanx> whose SCTs all have
-the <spanx style="verb">precert_entry_V2</spanx>
-<spanx style="verb">LogEntryType</spanx>.
-            </t>
-            <t>
-              Upon receiving the certificate, clients can reconstruct the
-original <spanx style="verb">TBSCertificate</spanx> to verify the SCT
-signatures.
-            </t>
-          </section>
+          </figure>
+          <t>
+            <spanx style="verb">PrecertificateSCTList</spanx> contains a <spanx style="verb">SignedCertificateTimestampList</spanx> whose SCTs all have the <spanx style="verb">precert_entry_V2</spanx> <spanx style="verb">LogEntryType</spanx>.
+          </t>
+          <t>
+            Upon receiving the certificate, clients can reconstruct the original <spanx style="verb">TBSCertificate</spanx> to verify the SCT signatures.
+          </t>
         </section>
       </section>
     </section>

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -314,9 +314,7 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
       </t>
       <section title="Certificates">
         <t>
-          Anyone can submit certificates to certificate logs;
-however, since certificates will not be accepted by TLS clients unless logged,
-it is expected that certificate owners or their CAs will usually submit them.
+          Anyone can <xref target="add_chain">submit a certificate</xref> to a log. Since certificates may not be accepted by TLS clients unless logged, it is expected that certificate owners or their CAs will usually submit them.
         </t>
       </section>
       <section title="Precertificates">
@@ -941,7 +939,7 @@ messages.
       <t>
         Clients SHOULD treat <spanx style="verb">500 Internal Server Error</spanx> and <spanx style="verb">503 Service Unavailable</spanx> responses as transient failures and MAY retry the same request without modification at a later date.  Note that as per <xref target="RFC2616"/>, in the case of a 503 response the log MAY include a <spanx style="verb">Retry-After:</spanx> header in order to request a minimum time for the client to wait before retrying the request.
       </t>
-      <section title="Add Chain to Log" anchor="sct">
+      <section title="Add Chain to Log" anchor="add_chain">
         <t>
           POST https://&lt;log server&gt;/ct/v2/add-chain
         </t>
@@ -1009,7 +1007,7 @@ an accepted root certificate.
           </list>
         </t>
         <t>
-          Outputs and errors are the same as in <xref target="sct"/>.
+          Outputs and errors are the same as in <xref target="add_chain"/>.
         </t>
       </section>
 

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -343,6 +343,77 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
         </t>
       </section>
     </section>
+    <section title="Private Domain Name Labels">
+      <t>
+        Some regard some DNS domain name labels within their registered domain space as private and security sensitive. Even though these domains are often only accessible within the domain owner's private network, it's common for them to be secured using publicly trusted TLS server certificates. We define a mechanism to allow these private labels to not appear in public logs.
+      </t>
+      <section title="Wildcard Certificates">
+        <t>
+          A certificate containing a <xref target="RFC6125">DNS-ID</xref> of <spanx style="verb">*.example.com</spanx> could be used to secure the domain <spanx style="verb">topsecret.example.com</spanx>, without revealing the string <spanx style="verb">topsecret</spanx> publicly.
+        </t>
+        <t>
+          Since TLS clients only match the wildcard character to the complete leftmost label of the DNS domain name (see Section 6.4.3 of <xref target="RFC6125"/>), this approach would not work for a DNS-ID such as <spanx style="verb">top.secret.example.com</spanx>. Also, wildcard certificates are prohibited in some cases, such as <xref target="EVSSLGuidelines">Extended Validation Certificates</xref>.
+        </t>
+      </section>
+      <section title="Redacting Domain Name Labels in Precertificates" anchor="redacting_subdomains">
+        <t>
+          When creating a precertificate, the CA MAY substitute one or more labels in each DNS-ID with a corresponding number of <spanx style="verb">?</spanx> labels. Every label to the left of a <spanx style="verb">?</spanx> label MUST also be redacted. For example, if a certificate contains a DNS-ID of <spanx style="verb">top.secret.example.com</spanx>, then the corresponding precertificate could contain <spanx style="verb">?.?.example.com</spanx> instead, but not <spanx style="verb">top.?.example.com</spanx> instead.
+        </t>
+        <t>
+          Wildcard <spanx style="verb">*</spanx> labels MUST NOT be redacted. However, if the complete leftmost label of a DNS-ID is <spanx style="verb">*</spanx>, it is considered redacted for the purposes of determining if the label to the right may be redacted. For example, if a certificate contains a DNS-ID of <spanx style="verb">*.top.secret.example.com</spanx>, then the corresponding precertificate could contain <spanx style="verb">*.?.?.example.com</spanx> instead, but not <spanx style="verb">?.?.?.example.com</spanx> instead.
+        </t>
+        <t>
+          When a precertificate contains one or more redacted labels, a non-critical extension (OID 1.3.6.1.4.1.11129.2.4.6, whose extnValue OCTET STRING contains an ASN.1 SEQUENCE OF INTEGERs) MUST be added to the corresponding certificate: the first INTEGER indicates the total number of redacted labels and wildcard <spanx style="verb">*</spanx> labels in the precertificate's first DNS-ID; the second INTEGER does the same for the precertificate's second DNS-ID; etc. There MUST NOT be more INTEGERs than there are DNS-IDs. If there are fewer INTEGERs than there are DNS-IDs, the shortfall is made up by implicitly repeating the last INTEGER. Each INTEGER MUST have a value of zero or more. The purpose of this extension is to enable TLS clients to accurately reconstruct the TBSCertificate component of the precertificate from the certificate without having to perform any guesswork.
+        </t>
+        <t>
+          When a precertificate contains that extension and contains a <xref target="RFC6125">CN-ID</xref>, the CN-ID MUST match the first DNS-ID and have the same labels redacted.  TLS clients will use the first entry in the SEQUENCE OF INTEGERs to reconstruct both the first DNS-ID and the CN-ID.
+        </t>
+      </section>
+      <section title="Using a Name-Constrained Intermediate CA" anchor="name_constrained">
+        <t>
+          An intermediate CA certificate or intermediate CA precertificate that contains the critical or non-critical <xref target="RFC5280">Name Constraints</xref> extension MAY be logged in place of end-entity certificates issued by that intermediate CA, as long as all of the following conditions are met:
+          <list style="symbols">
+            <t>
+              there MUST be a non-critical extension (OID 1.3.6.1.4.1.11129.2.4.7, whose extnValue OCTET STRING contains ASN.1 NULL data (0x05 0x00)). This extension is an explicit indication that it is acceptable to not log certificates issued by this intermediate CA.
+            </t>
+            <t>
+              permittedSubtrees MUST specify one or more dNSNames.
+            </t>
+            <t>
+              excludedSubtrees MUST specify the entire IPv4 and IPv6 address ranges.
+            </t>
+          </list>
+        </t>
+        <figure>
+          <preamble>
+            Below is an example Name Constraints extension that meets these conditions:
+          </preamble>
+          <artwork>
+    SEQUENCE {
+      OBJECT IDENTIFIER '2 5 29 30'
+      OCTET STRING, encapsulates {
+        SEQUENCE {
+          [0] {
+            SEQUENCE {
+              [2] 'example.com'
+              }
+            }
+          [1] {
+            SEQUENCE {
+              [7] 00 00 00 00 00 00 00 00
+              }
+            SEQUENCE {
+              [7]
+                00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+                00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+              }
+            }
+          }
+        }
+      }</artwork>
+        </figure>
+      </section>
+    </section>
     <section title="Log Format and Operation">
       <t>
         A log is a single, append-only Merkle Tree of such certificates.
@@ -416,125 +487,6 @@ certificate. Logs MUST also reject precertificates that are not valid DER encode
         <t>
           <spanx style="verb">precertificate_chain</spanx> is a chain of additional certificates required to verify the precertificate submission. The first certificate MUST certify the precertificate. Each following certificate MUST directly certify the one preceding it. The final certificate MUST be a root certificate accepted by the log.
         </t>
-      </section>
-      <section title="Private Domain Name Labels">
-        <t>
-          Some regard some DNS domain name labels within their registered
-domain space as private and security sensitive. Even though these domains are
-often only accessible within the domain owner's private network, it's common for
-them to be secured using publicly trusted TLS server certificates. We define a mechanism to allow these private labels to not appear in public logs.
-        </t>
-        <section title="Wildcard Certificates">
-          <t>
-            A certificate containing a <xref target="RFC6125">DNS-ID</xref> of
-<spanx style="verb">*.example.com</spanx> could be used to secure the domain
-<spanx style="verb">topsecret.example.com</spanx>, without revealing the string
-<spanx style="verb">topsecret</spanx> publicly.
-          </t>
-          <t>
-            Since TLS clients only match the wildcard character to the complete
-leftmost label of the DNS domain name (see Section 6.4.3 of
-<xref target="RFC6125"/>), this approach would not work for a DNS-ID such as
-<spanx style="verb">top.secret.example.com</spanx>.  Also, wildcard certificates
-are prohibited in some cases, such as <xref target="EVSSLGuidelines">Extended
-Validation Certificates</xref>.
-          </t>
-        </section>
-        <section title="Redacting Domain Name Labels in Precertificates" anchor="redacting_subdomains">
-          <t>
-            When creating a precertificate, the CA MAY substitute one or more
-labels in each DNS-ID with a corresponding number of
-<spanx style="verb">?</spanx> labels. Every label to the left of a
-<spanx style="verb">?</spanx> label MUST also be redacted. For example, if a
-certificate contains a DNS-ID of
-<spanx style="verb">top.secret.example.com</spanx>, then the corresponding
-precertificate could contain <spanx style="verb">?.?.example.com</spanx>
-instead, but not <spanx style="verb">top.?.example.com</spanx> instead.
-          </t>
-          <t>
-            Wildcard <spanx style="verb">*</spanx> labels MUST NOT be redacted.
-However, if the complete leftmost label of a DNS-ID is
-<spanx style="verb">*</spanx>, it is considered redacted for the purposes of
-determining if the label to the right may be redacted. For example, if a
-certificate contains a DNS-ID of
-<spanx style="verb">*.top.secret.example.com</spanx>, then the corresponding
-precertificate could contain
-<spanx style="verb">*.?.?.example.com</spanx> instead, but not
-<spanx style="verb">?.?.?.example.com</spanx> instead.
-          </t>
-          <t>
-            When a precertificate contains one or more redacted labels, a
-non-critical extension (OID 1.3.6.1.4.1.11129.2.4.6, whose extnValue OCTET STRING
-contains an ASN.1 SEQUENCE OF INTEGERs) MUST be added to the corresponding
-certificate: the first INTEGER indicates the total number of redacted labels
-and wildcard <spanx style="verb">*</spanx> labels in the
-precertificate's first DNS-ID; the second INTEGER does the same for the
-precertificate's second DNS-ID; etc. There MUST NOT be more INTEGERs than there
-are DNS-IDs. If there are fewer INTEGERs than there are DNS-IDs, the shortfall
-is made up by implicitly repeating the last INTEGER. Each INTEGER MUST have a
-value of zero or more. The purpose of this extension is to enable TLS clients
-to accurately reconstruct the TBSCertificate component of the precertificate
-from the certificate without having to perform any guesswork.
-          </t>
-          <t>
-            When a precertificate contains that extension and contains a
-<xref target="RFC6125">CN-ID</xref>, the CN-ID MUST match the first DNS-ID and
-have the same labels redacted.  TLS clients will use the first
-entry in the SEQUENCE OF INTEGERs to reconstruct both the first DNS-ID and the
-CN-ID.
-          </t>
-        </section>
-        <section title="Using a Name-Constrained Intermediate CA" anchor="name_constrained">
-          <t>
-            An intermediate CA certificate or intermediate CA precertificate that contains the
-critical or non-critical <xref target="RFC5280">Name Constraints</xref> extension
-MAY be logged in place of end-entity certificates issued by that intermediate
-CA, as long as all of the following conditions are met:
-            <list style="symbols">
-              <t>
-                there MUST be a non-critical extension (OID 1.3.6.1.4.1.11129.2.4.7,
-whose extnValue OCTET STRING contains ASN.1 NULL data (0x05 0x00)). This
-extension is an explicit indication that it is acceptable to not log
-certificates issued by this intermediate CA.
-              </t>
-              <t>
-                permittedSubtrees MUST specify one or more dNSNames.
-              </t>
-              <t>
-                excludedSubtrees MUST specify the entire IPv4 and IPv6 address
-ranges.
-              </t>
-            </list>
-          </t>
-          <figure>
-            <preamble>
-              Below is an example Name Constraints extension that meets these conditions:
-            </preamble>
-            <artwork>
-    SEQUENCE {
-      OBJECT IDENTIFIER '2 5 29 30'
-      OCTET STRING, encapsulates {
-        SEQUENCE {
-          [0] {
-            SEQUENCE {
-              [2] 'example.com'
-              }
-            }
-          [1] {
-            SEQUENCE {
-              [7] 00 00 00 00 00 00 00 00
-              }
-            SEQUENCE {
-              [7]
-                00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-                00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-              }
-            }
-          }
-        }
-      }</artwork>
-          </figure>
-        </section>
       </section>
       <section title="Structure of the Signed Certificate Timestamp">
         <figure>

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -1145,13 +1145,7 @@ entry specified by <spanx style="verb">start</spanx>.
       </t>
       <section title="TLS Extension" anchor="tls_sctlist_extension">
         <t>
-          One or more SCTs can be sent during the TLS handshake using a TLS extension with type <spanx style="verb">signed_certificate_timestamp</spanx>.
-        </t>
-        <t>
-          TLS clients that support the extension SHOULD send a ClientHello extension with the appropriate type and empty <spanx style="verb">extension_data</spanx>.
-        </t>
-        <t>
-          TLS servers MUST only send SCTs in this TLS extension to TLS clients that have indicated support for the extension in the ClientHello, in which case the SCTs are sent by setting the <spanx style="verb">extension_data</spanx> to a <spanx style="verb">SignedCertificateTimestampList</spanx>.
+          If a TLS client includes the <spanx style="verb">signed_certificate_timestamp</spanx> extension type in the ClientHello, the TLS server MAY include the <spanx style="verb">signed_certificate_timestamp</spanx> extension in the ServerHello with the <spanx style="verb">extension_data</spanx> set to a <spanx style="verb">SignedCertificateTimestampList</spanx>.
         </t>
         <t>
           Session resumption uses the original session information: TLS clients SHOULD include the extension type in the ClientHello, but if the session is resumed, the TLS server is not expected to process it or include the extension in the ServerHello.
@@ -1248,7 +1242,7 @@ but it is expected there will be a variety.
       </section>
       <section title="TLS Client" anchor="tls_clients">
         <t>
-          TLS clients receive SCTs alongside or in certificates, either for the server certificate itself or for a name-constrained intermediate the server certificate chains to. TLS clients MUST implement all of the three mechanisms by which TLS servers may present SCTs (see <xref target="tls_servers"/>).
+          TLS clients receive SCTs alongside or in certificates, either for the server certificate itself or for a name-constrained intermediate the server certificate chains to. TLS clients MUST implement all of the three mechanisms by which TLS servers may present SCTs (see <xref target="tls_servers"/>). TLS clients that support the <spanx style="verb">signed_certificate_timestamp</spanx> TLS extension SHOULD include it, with empty <spanx style="verb">extension_data</spanx>, in ClientHello messages.
         </t>
         <t>
           In addition to normal validation of the certificate and its chain, TLS clients SHOULD validate each SCT by computing the signature input from the SCT data as well as the certificate and verifying the signature, using the corresponding log's public key. TLS clients MUST reject SCTs whose timestamp is in the future.

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -1160,6 +1160,8 @@ entry specified by <spanx style="verb">start</spanx>.
           Session resumption uses the original session information: TLS clients SHOULD include the extension type in the ClientHello, but if the session is resumed, the TLS server is not expected to process it or include the extension in the ServerHello.
         </t>
       </section>
+    </section>
+    <section title="Certification Authorities">
       <section title="X.509v3 Extension" anchor="x509v3_extension">
         <t>
           One or more SCTs can be embedded in an X.509v3 extension that is included in a certificate or an OCSP response. Since RFC5280 requires the <spanx style="verb">extnValue</spanx> field (an OCTET STRING) of each X.509v3 extension to include the DER encoding of an ASN.1 value, we cannot embed a <spanx style="verb">SignedCertificateTimestampList</spanx> directly. Instead, we have to wrap it inside an additional OCTET STRING (see below), which we then put into the <spanx style="verb">extnValue</spanx> field.


### PR DESCRIPTION
The Log Format and Operation section should describe just that.  This PR moves requirements for other parties (Submitters, CAs, TLS servers and TLS clients) into more appropriate sections.