### PR TITLE
Change the LogID length to fit into one byte.

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -492,7 +492,7 @@ Section 8.2 of <xref target="RFC3447"/>) using a key of at least 2048 bits.
         v2(1), (255)
     } Version;
 
-    opaque LogID&lt;1..2^8-1&gt;;
+    opaque LogID&lt;2..127&gt;;
 
     opaque TBSCertificate&lt;1..2^24-1&gt;;
 
@@ -558,7 +558,7 @@ labels extension.
 protocol to which the SCT conforms. This version is v2. Note that <xref target="RFC6962">SignedCertificateTimestamp v1</xref> had a different definition of <spanx style="verb">signed_entry</spanx>.
         </t>
         <t>
-          <spanx style="verb">log_id</spanx> is the DER encoding of an OID, excluding the ASN.1 tag and length bytes, that the log operator has allocated for the purpose of uniquely identifying this log. This OID is specified in the log's metadata.
+          <spanx style="verb">log_id</spanx> is the DER encoding of an OID, excluding the ASN.1 tag and length bytes, that the log operator has allocated for the purpose of uniquely identifying this log. Note that the ASN.1 length and the opaque vector length are identical in size (1 byte) and value, so the DER encoding of the OID can be reproduced simply by prepending an OBJECT IDENTIFIER tag (0x06) to the opaque vector length and contents. This OID is specified in the log's metadata.
         </t>
         <t>
           <spanx style="verb">timestamp</spanx> is the current <xref target="RFC5905">NTP Time</xref>, measured since the epoch (January 1, 1970, 00:00), ignoring leap seconds, in milliseconds.


### PR DESCRIPTION
That yields a valid DER-encoded ASN.1 OID by prepending the tag 0x06 to
the LogID bytes.