### PR TITLE
Ticket 78: More text about algorithm agility

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -1460,7 +1460,14 @@ but it is expected there will be a variety.
 
     <section title="Algorithm Agility">
       <t>
-        It is not possible for a log to change any of its algorithms part way through its lifetime. If it should become necessary to deprecate an algorithm used by a live log, then the log should be frozen as specified in <xref target="metadata"/> and a new log should be started. If necessary, the new log can contain existing entries from the frozen log, which monitors can verify are an exact match.
+        It is not possible for a log to change any of its algorithms part way through its lifetime:
+        <list style="hanging">
+          <t hangText="Signature algorithm:">SCT signatures must remain valid so signature algorithms can only be added, not removed.</t>
+          <t hangText="Hash algorithm:">A log would have to support the old and new hash algorithms to allow backwards-compatibility with clients that are not aware of a hash algorithm change. </t>
+        </list>
+        Allowing multiple signature or hash algorithms for a log would require that all data structures support it and would significantly complicate client implementation, which is why it is not supported by this document.
+      </t>
+      <t>If it should become necessary to deprecate an algorithm used by a live log, then the log should be frozen as specified in <xref target="metadata"/> and a new log should be started. Certificates in the frozen log that have not yet expired and require new SCTs should be submitted to the new log and the SCTs from that log used instead.
       </t>
     </section>
 


### PR DESCRIPTION
The added text should make it clear why supporting algorithm agility (in practice, allowing logs to support multiple signature and hash algorithms) is too complex and unnecessary given the simpler alternative of freezing a log.