### PR TITLE
Address issue 132.

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -1460,7 +1460,7 @@ but it is expected there will be a variety.
 
     <section title="Algorithm Agility">
       <t>
-        It is not possible for a log to change any of its algorithms part way through its lifetime. If it should become necessary to deprecate an algorithm used by a live log, then the log should be frozen as specified in <xref target="metadata"/> and a new log should be started. If necessary, the new log can contain existing entries from the frozen log, which monitors can verify are an exact match.
+        It is not possible for a log to change any of its algorithms part way through its lifetime. If it should become necessary to deprecate an algorithm used by a live log, then the log should be frozen as specified in <xref target="metadata"/> and a new log should be started.
       </t>
     </section>
 


### PR DESCRIPTION
I propose that we remove the confusing text as this isn't something we can cover in a single sentence and it doesn't seem that helpful to implementers.

Additionally, attempts to be prescriptive about operational events like this are likely to be incomplete and create uncertainty for log operators.

Please review and advise me if if there are things that logs are required to do in these circumstances that are not covered in the referenced section 9.1.