### PR TITLE
Ticket 120: Clarify this is about the protocol.

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -305,7 +305,7 @@ d0 d1   d2 d3           d0 d1   d2 d3  d4 d5</artwork>
       </t>
       <section title="Certificates">
         <t>
-          Anyone can <xref target="add-chain">submit a certificate</xref> to a log. Since certificates may not be accepted by TLS clients unless logged, it is expected that certificate owners or their CAs will usually submit them.
+          Any entity can <xref target="add-chain">submit a certificate</xref> to a log. Since certificates may not be accepted by TLS clients unless logged, it is expected that certificate owners or their CAs will usually submit them.
         </t>
       </section>
       <section title="Precertificates" anchor="Precertificates">


### PR DESCRIPTION
It should be clear that certificate submission is not limited to one
entity in the protocol. Whether submitted certificates are accepted
by a log or not is up to the log's policy.