### PR TITLE
Ticket 153: Explain V1/V2 interoperability.

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -496,6 +496,7 @@ d0 d1   d2 d3           d0 d1   d2 d3  d4 d5</artwork>
     } TransType;
 
     struct {
+        Version version;
         TransType type;
         select (type) {
             case x509_entry: TimestampedCertificateEntryDataV2;
@@ -507,18 +508,11 @@ d0 d1   d2 d3           d0 d1   d2 d3  d4 d5</artwork>
             case consistency_proof: ConsistencyProofDataV2;
             case inclusion_proof: InclusionProofDataV2;
         } data;
-    } TransItemV2;
-
-    struct {
-        Version version;
-        select (version) {
-            case v1: TransItemV1;
-            case v2: TransItemV2;
-        }
-    } TransItem;</artwork>
+    } TransItem;
+          </artwork>
         </figure>
         <t>
-          <spanx style="verb">version</spanx> is the earliest version of this protocol to which the encapsulated data structure conforms. This document is v2. Note that <xref target="RFC6962">v1</xref> did not define <spanx style="verb">TransItem</spanx>, but this document specifies a mechanism (see <xref target="TransItemV1"/>) for v2 implementations to encapsulate existing v1 objects in the <spanx style="verb">TransItem</spanx> structure. Note also that, since each <spanx style="verb">TransItem</spanx> object is individually versioned, future revisions to this protocol could conceivably update some encapsulated data structures without having to update all of them.
+          <spanx style="verb">version</spanx> is the earliest version of this protocol to which the encapsulated data structure conforms. This document is v2. Note that <xref target="RFC6962">v1</xref> did not define <spanx style="verb">TransItem</spanx>, but this document provides guidelines (see <xref target="v1_coexistence"/>) on how v2 implementations can co-exist with v1 implementations. Note also that, since each <spanx style="verb">TransItem</spanx> object is individually versioned, the version should be increased only if changes to it are made that are not backwards-compatible. The addition of encapsulated data structures can be done by adding <spanx style="verb">TransType</spanx> values without increasing the version.
         </t>
         <t>
           <spanx style="verb">type</spanx> is the type of the encapsulated data structure. (Note that <spanx style="verb">TransType</spanx> combines the v1 type enumerations <spanx style="verb">LogEntryType</spanx>, <spanx style="verb">SignatureType</spanx> and <spanx style="verb">MerkleLeafType</spanx>). Future revisions of this protocol may add new <spanx style="verb">TransType</spanx> values.
@@ -1310,6 +1304,9 @@ but it is expected there will be a variety.
             </list>
             A certificate with redacted labels where one of the redacted labels is <spanx style="verb">*</spanx> MUST NOT be considered compliant.
           </t>
+          <t>
+            If the SCT checked is for a Precertificate (where the <spanx style="verb">type</spanx> of the <spanx style="verb">TransItem</spanx> is <spanx style="verb">precert_sct</spanx>), then the client SHOULD also remove embedded v1 SCTs, identified by OID 1.3.6.1.4.1.11129.2.4.2 (See Section 3.3. of <xref target="RFC6962"/>), in the process of reconstructing the TBSCertificate. That is to allow embedded v1 and v2 SCTs to co-exist in a certificate (See <xref target="v1_coexistence"/>).
+          </t>
         </section>
         <section title="Validating SCTs">
           <t>
@@ -1856,71 +1853,35 @@ value="Montreal"/>
 
     </references>
 
-    <section title="TransItemV1" anchor="TransItemV1">
-      <figure>
-        <preamble>
-          TODO: Finish writing this section. Or should it be in a separate document?
-        </preamble>
-        <artwork>
-    struct {
-        TransType type;
-        select (type) {
-            case x509_sct: SignedCertificateTimestampV1;
-            case precert_sct: SignedCertificateTimestampV1;
-            case signed_tree_head: SignedTreeHeadDataV1;
-            case consistency_proof: ConsistencyProofDataV1;
-            case inclusion_proof: InclusionProofDataV1;
-        } data;
-    } TransItemV1;
-
-    opaque SHA256Hash[32];
-
-    struct {
-        Version version = v1;
-        SHA256Hash log_id;
-        uint64 timestamp;
-        SctExtensions extensions;
-        digitally-signed struct {
-            Version version = v1;
-            uint8 signature_type = 0;  /* "certificate_timestamp" */
-            uint64 timestamp;
-            TransType type;  /* x509_entry(0) or precert_entry(1) */
-            select (type) {
-                case x509_entry: ASN.1Cert;
-                case precert_entry: PreCert;
-            } signed_entry;
-            SctExtensions extensions;
-        } signature;
-    } SignedCertificateTimestampV1;
-
-    struct {
-        SHA256Hash log_id;
-        uint64 timestamp;
-        uint64 tree_size;
-        SHA256Hash sha256_root_hash;
-        digitally-signed struct {
-            Version version = v1;
-            uint8 signature_type = 1;  /* "tree_hash" */
-            uint64 timestamp;
-            uint64 tree_size;
-            SHA256Hash sha256_root_hash;
-        } signature;
-    } SignedTreeHeadDataV1;
-
-    struct {
-        SHA256Hash log_id;
-        uint64 tree_size_1;
-        uint64 tree_size_2;
-        SHA256Hash consistency_path&lt;1..2^8-1&gt;;
-    } ConsistencyProofDataV1;
-
-    struct {
-        SHA256Hash log_id;
-        uint64 tree_size;
-        uint64 leaf_index;
-        SHA256Hash inclusion_path&lt;1..2^8-1&gt;;
-    } InclusionProofDataV1;</artwork>
-      </figure>
+    <section title="Supporting v1 and v2 simultaneously" anchor="v1_coexistence">
+      <t>
+        Certificate Transparency logs have to be either v1 (conforming to <xref target="RFC6962"/>) or v2 (conforming to this document), as the data structures are incompatible and so a v2 log could not issue a valid v1 SCT.
+      </t>
+      <t>
+        CT clients, however, can support v1 and v2 SCTs, for the same certificate, simultaneously, as v1 SCTs are delivered in different TLS, X.509 and OCSP extensions than v2 SCTs.
+      </t>
+      <t>
+        v1 and v2 SCTs for X.509 certificates can be validated independently.
+        For precertificates, v2 SCTs should be embedded in the TBSCertificate before submission of the TBSCertificate (inside a v1 precertificate, as described in Section 3.1. of <xref target="RFC6962"/>) to a v1 log so that TLS clients conforming to <xref target="RFC6962"/> but not this document are oblivious to the embedded v2 SCTs.
+        An issuer can follow these steps to produce an X.509 certificate with embedded v1 and v2 SCTs:
+        <list style="symbols">
+          <t>
+            Create a CMS precertificate as described in <xref target="Precertificates"/> and submit it to v2 logs.
+          </t>
+          <t>
+            Embed the obtained v2 SCTs in the TBSCertificate, as described in <xref target="cert_transinfo_extension"/>.
+          </t>
+          <t>
+            Use that TBSCertificate to create a v1 precertificate, as described in Section 3.1. of <xref target="RFC6962"/> and submit it to v1 logs.
+          </t>
+          <t>
+            Embed the v1 SCTs in the TBSCertificate, as described in Section 3.3. of <xref target="RFC6962"/>.
+          </t>
+          <t>
+            Sign that TBSCertificate (which now contains v1 and v2 SCTs) to issue the final X.509 certificate.
+          </t>
+        </list>
+      </t>
     </section>
   </back>
 </rfc>


### PR DESCRIPTION
V1 and V2 SCTs can co-exist for X.509 certificates, but not precertificates.
I've briefly explored the option of allowing V2 SCTs to be valid for V1 precerts
by specifying that V2 clients should remove the X.509 extension with V1 SCTs
prior to checking V2 SCT signatures.

However it is unclear the complication is worth it as V1 clients will not
be able to use V2 SCTs, so the benefit is unclear.