### PR TITLE
Logs must issue SCTs for all accepted submissions

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -846,10 +846,7 @@ messages.
           If the version of <spanx style="verb">sct</spanx> is not v2, then a v2 client may be unable to verify the signature. It MUST NOT construe this as an error. This is to avoid forcing an upgrade of compliant v2 clients that do not use the returned SCTs.
         </t>
         <t>
-          If a log detects bad encoding in a chain that otherwise verifies correctly then the log MAY still log the certificate but SHOULD NOT return an SCT. It should instead return the "bad certificate" error. Logging the certificate is useful, because <xref target="monitor">monitors</xref> can then detect these encoding errors, which may be accepted by some TLS clients.
-        </t>
-        <t>
-          Note that not all certificate handling software is capable of detecting all encoding errors (e.g. some software will accept BER instead of DER encodings in certificates, or incorrect character encodings, even though these are technically incorrect) .
+          If a log detects bad encoding in a chain that otherwise verifies correctly then the log MUST either log the certificate or return the "bad certificate" error. If the certificate is logged, an SCT MUST be issued. Logging the certificate is useful, because <xref target="monitor">monitors</xref> can then detect these encoding errors, which may be accepted by some TLS clients.
         </t>
       </section>
 


### PR DESCRIPTION
Change behaviour to require that if a log accepts a submission it must issue an SCT, but it may reject it with "bad certificate" if it detects bad encoding.

Reasoning:
* get-entries specifies that each entry returned is accompanied by an SCT.
* Without an SCT for each entry, the client is forced to identify the encoding error, to figure out if it's justified that the log did not supply an SCT.
* Given that not all SSL software can identify encoding errors, it may be best to leave it to monitors to scrutinize each entry and allow logs to treat these submissions, if they can process them (and choose to) to treat them like regular entries. Right now there's no provisioning in the tree-related data structure to single out "badly encoded" entries, so in essence a timestamp will have to be assigned to them. Might as well sign it and give it back to submitters.