### PR TITLE
Clarity - "consists of" -> "contains"

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -89,7 +89,7 @@ document, we only describe its use for public TLS server certificates issued by
 public certification authorities (CAs).
       </t>
       <t>
-        Each log consists of certificate chains, which can be submitted by anyone. It is expected that public CAs will contribute all their newly issued certificates to one or more logs, however certificate holders can also contribute their own certificate chains, as can third parties. In order to avoid logs being rendered useless by the submission of large numbers of spurious certificates, it is required that each chain ends with a trust anchor that is accepted by the log. When a chain is accepted by a log, a signed timestamp is returned, which can later be used to provide evidence to TLS clients that the chain has been submitted. TLS clients can thus require that all certificates they accept as valid are accompanied by signed timestamps.
+        Each log contains certificate chains, which can be submitted by anyone. It is expected that public CAs will contribute all their newly issued certificates to one or more logs, however certificate holders can also contribute their own certificate chains, as can third parties. In order to avoid logs being rendered useless by the submission of large numbers of spurious certificates, it is required that each chain ends with a trust anchor that is accepted by the log. When a chain is accepted by a log, a signed timestamp is returned, which can later be used to provide evidence to TLS clients that the chain has been submitted. TLS clients can thus require that all certificates they accept as valid are accompanied by signed timestamps.
       </t>
       <t>
         Those who are concerned about misissuance can monitor the logs, asking


### PR DESCRIPTION
"Each log consists of certificate chains" -> "Each log contains certificate chains..." 

"consists of" makes it sound like certificate chains are the only thing in the log.
I'm suggesting "contains", but I'm not sure it is much better. 
Feel free to reject / ignore.

Apologies,  diff not highlighting changes again.