### PR TITLE
The subjectAltName extension is optional.

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -359,7 +359,7 @@ d0 d1   d2 d3           d0 d1   d2 d3  d4 d5</artwork>
       <section title="Redaction of Domain Name Labels" anchor="domain_name_redaction">
         <section title="Redacting Labels in Precertificates" anchor="redacting_labels">
           <t>
-            When creating a precertificate, the CA MAY omit the subjectAltName extension. Instead, the CA MUST include a <xref target="redacted_san_extension">redactedSubjectAltName</xref> extension that contains, in a redacted form, the same identities that will be included in the certificate's subjectAltName extension.
+            When creating a precertificate, the CA MAY omit the the subjectAltName extension, even if it intends to include the extension in the final certificate. Instead, the CA MUST include a <xref target="redacted_san_extension">redactedSubjectAltName</xref> extension that contains, in a redacted form, the same identities that will be included in the certificate's subjectAltName extension.
           </t>
           <figure>
             <preamble>
@@ -463,6 +463,9 @@ REDACT(label) = prefix || BASE32(index || LABELHASH(keyid || label))</artwork>
       <section title="Accepting Submissions">
         <t>
           Logs MUST verify that each submitted certificate or precertificate has a valid signature chain to an accepted trust anchor, using the chain of intermediate CA certificates provided by the submitter. Logs MUST accept certificates and precertificates that are fully valid according to <xref target="RFC5280">RFC 5280</xref> verification rules and are submitted with such a chain. Logs MAY accept certificates and precertificates that have expired, are not yet valid, have been revoked, or are otherwise not fully valid according to RFC 5280 verification rules in order to accommodate quirks of CA certificate-issuing software. However, logs MUST reject submissions without a valid signature chain to an accepted trust anchor. Logs MUST also reject precertificates that do not conform to the requirements in <xref target="Precertificates"/>.
+        </t>
+        <t>
+          Logs MUST reject submission of precertificates where both the subjectAltName and <xref target="redacted_san_extension">redactedSubjectAltName</xref> extensions are present.
         </t>
         <t>
           Logs SHOULD limit the length of chain they will accept. The maximum chain length is specified in the log's metadata.

--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -330,7 +330,7 @@ d0 d1   d2 d3           d0 d1   d2 d3  d4 d5</artwork>
                   the <xref target="x509v3_transinfo_extension">Transparency Information</xref> extension MUST be omitted.
                 </t>
                 <t>
-                  the <xref target="RFC5280">subjectAltName</xref> extension MUST be omitted when the CA is using <xref target="domain_name_redaction">domain name redaction</xref>.
+                  the <xref target="RFC5280">subjectAltName</xref> extension MUST be omitted when the <xref target="redacted_san_extension">redactedSubjectAltName</xref> extension is present.
                 </t>
               </list>
             </t>
@@ -359,7 +359,7 @@ d0 d1   d2 d3           d0 d1   d2 d3  d4 d5</artwork>
       <section title="Redaction of Domain Name Labels" anchor="domain_name_redaction">
         <section title="Redacting Labels in Precertificates" anchor="redacting_labels">
           <t>
-            When creating a precertificate, the CA MAY omit the the subjectAltName extension, even if it intends to include the extension in the final certificate. Instead, the CA MUST include a <xref target="redacted_san_extension">redactedSubjectAltName</xref> extension that contains, in a redacted form, the same identities that will be included in the certificate's subjectAltName extension.
+            When creating a precertificate, the CA MAY omit the subjectAltName extension, even if it intends to include the extension in the final certificate. If omitting the subjectAltName extension, the CA MUST include a <xref target="redacted_san_extension">redactedSubjectAltName</xref> extension that contains, in a redacted form, the same identities that will be included in the certificate's subjectAltName extension.
           </t>
           <figure>
             <preamble>
@@ -463,9 +463,6 @@ REDACT(label) = prefix || BASE32(index || LABELHASH(keyid || label))</artwork>
       <section title="Accepting Submissions">
         <t>
           Logs MUST verify that each submitted certificate or precertificate has a valid signature chain to an accepted trust anchor, using the chain of intermediate CA certificates provided by the submitter. Logs MUST accept certificates and precertificates that are fully valid according to <xref target="RFC5280">RFC 5280</xref> verification rules and are submitted with such a chain. Logs MAY accept certificates and precertificates that have expired, are not yet valid, have been revoked, or are otherwise not fully valid according to RFC 5280 verification rules in order to accommodate quirks of CA certificate-issuing software. However, logs MUST reject submissions without a valid signature chain to an accepted trust anchor. Logs MUST also reject precertificates that do not conform to the requirements in <xref target="Precertificates"/>.
-        </t>
-        <t>
-          Logs MUST reject submission of precertificates where both the subjectAltName and <xref target="redacted_san_extension">redactedSubjectAltName</xref> extensions are present.
         </t>
         <t>
           Logs SHOULD limit the length of chain they will accept. The maximum chain length is specified in the log's metadata.


### PR DESCRIPTION
CAs do not have to include the  subjectAltName extension (this is a BR). Indicate that the subjectAltName extension may be omitted even if it's to be included in the final certificate.

Also, clarify that logs MUST reject a submission where both the subjectAltName and redactedSAN extensions are present, since they make no sense.