### PR TITLE
Allowing more space for nodes in proofs.

### DIFF
--- a/rfc6962-bis.xml
+++ b/rfc6962-bis.xml
@@ -744,7 +744,7 @@ d0 d1   d2 d3           d0 d1   d2 d3  d4 d5</artwork>
         LogID log_id;
         uint64 tree_size_1;
         uint64 tree_size_2;
-        NodeHash consistency_path&lt;1..2^8-1&gt;;
+        NodeHash consistency_path&lt;1..2^16-1&gt;;
     } ConsistencyProofDataV2;</artwork>
         </figure>
         <t>
@@ -770,7 +770,7 @@ d0 d1   d2 d3           d0 d1   d2 d3  d4 d5</artwork>
         LogID log_id;
         uint64 tree_size;
         uint64 leaf_index;
-        NodeHash inclusion_path&lt;1..2^8-1&gt;;
+        NodeHash inclusion_path&lt;1..2^16-1&gt;;
     } InclusionProofDataV2;</artwork>
         </figure>
         <t>


### PR DESCRIPTION
The way it's currently specified there can only be 7 repeated nodes for SHA-256 hash, for example (which fit in 255 bytes), which is not enough for large logs.