### PR TITLE
Workaround xml2rfc breakage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ XML=$(DOC).xml
 all: $(TEXT) $(HTML) 
 
 $(XML): $(DOC).md
-	kramdown-rfc2629 $< > $@
+	XML_RESOURCE_ORG_PREFIX="https://xml2rfc.tools.ietf.org/public/rfc" kramdown-rfc2629 $< > $@
 
 $(TEXT): $(XML)
 	xml2rfc $<

--- a/dns/Makefile
+++ b/dns/Makefile
@@ -10,7 +10,7 @@ XML=$(DOC).xml
 all: $(TEXT) $(HTML) 
 
 $(XML): $(DOC).md
-	kramdown-rfc2629 $< > $@
+	XML_RESOURCE_ORG_PREFIX="https://xml2rfc.tools.ietf.org/public/rfc" kramdown-rfc2629 $< > $@
 
 $(TEXT): $(XML)
 	xml2rfc $<

--- a/redaction/Makefile
+++ b/redaction/Makefile
@@ -10,7 +10,7 @@ XML=$(DOC).xml
 all: $(TEXT) $(HTML) 
 
 $(XML): $(DOC).md
-	kramdown-rfc2629 $< > $@
+	XML_RESOURCE_ORG_PREFIX="https://xml2rfc.tools.ietf.org/public/rfc" kramdown-rfc2629 $< > $@
 
 $(TEXT): $(XML)
 	xml2rfc $<


### PR DESCRIPTION
It seems that the xml2rfc tools server was recently relocated, but kramdown-rfc2629 can't cope with the redirection.  This PR implements a (hopefully temporary) workaround.

.refcache/reference.RFC.2119.xml: fetching
/usr/lib64/ruby/2.1.0/open-uri.rb:223:in `open_loop': redirection forbidden: http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml -> https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml (RuntimeError)
        from /usr/lib64/ruby/2.1.0/open-uri.rb:149:in `open_uri'
        from /usr/lib64/ruby/2.1.0/open-uri.rb:704:in `open'
        from /usr/lib64/ruby/2.1.0/open-uri.rb:34:in `open'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:436:in `block in get_and_cache_resource'
        from /usr/lib64/ruby/2.1.0/timeout.rb:90:in `block in timeout'
        from /usr/lib64/ruby/2.1.0/timeout.rb:33:in `block in catch'
        from /usr/lib64/ruby/2.1.0/timeout.rb:33:in `catch'
        from /usr/lib64/ruby/2.1.0/timeout.rb:33:in `catch'
        from /usr/lib64/ruby/2.1.0/timeout.rb:105:in `timeout'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:435:in `get_and_cache_resource'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:487:in `block in convert_img'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:482:in `scan'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:482:in `convert_img'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:125:in `block in inner_a'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:123:in `map'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:123:in `inner_a'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:130:in `inner'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:143:in `convert_p'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:125:in `block in inner_a'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:123:in `map'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:123:in `inner_a'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:130:in `inner'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:615:in `convert_root'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:118:in `convert1'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/lib/kramdown-rfc2629.rb:113:in `convert'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-1.12.0/lib/kramdown/converter/base.rb:105:in `convert'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-1.12.0/lib/kramdown/document.rb:120:in `method_missing'
        from /home/rob/.gem/ruby/2.1.0/gems/kramdown-rfc2629-1.0.33/bin/kramdown-rfc2629:341:in `<top (required)>'
        from /usr/local/bin/kramdown-rfc2629:23:in `load'
        from /usr/local/bin/kramdown-rfc2629:23:in `<main>'