### PR TITLE
Issue #186 - Add a registry for error codes

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -995,8 +995,9 @@ error_message:
   detail for the error to be rectified.
 
 error_code:
-: An error code readable by the client. Some codes are generic and are detailed
-  here. Others are detailed in the individual requests. Error codes are fixed
+: An error code readable by the client. Other than the generic codes detailed
+  here, each error codes is specific to individual type of request.  Specific
+  errors are specified in the respective sections below. Error codes are fixed
   text strings.
 
 |---------------+---------------------------------------------|


### PR DESCRIPTION
This PR doesn't add a registry, but makes clear why one isn't necessary.  In particular, there is explicitly no extensibility for reusable error codes.