### PR TITLE
Issue 165: Clarify operational restrictions on logs

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -660,18 +660,20 @@ Tree no later than a fixed amount of time, known as the Maximum Merge Delay
 (MMD), after the issuance of the SCT. Periodically, the log MUST append all its
 new entries to its Merkle Tree and sign the root of the tree.
 
-Log operators MUST NOT impose any conditions on retrieving or sharing data from
-the log.
+Log operators SHOULD NOT impose any conditions on retrieving or sharing data
+from the log.
 
 ## Accepting Submissions
 
-Before accepting a submitted certificate or precertificate, the log MUST verify
-that it has a valid signature chain to an accepted trust anchor, using the chain
-of intermediate CA certificates provided by the submitter. Logs SHOULD accept
-certificates and precertificates that are fully valid according to RFC 5280
-[RFC5280] verification rules and are submitted with such a chain (A log may
-decide, for example, to temporarily reject valid submissions to protect itself
-against denial-of-service attacks).
+To avoid being overloaded by invalid submissions, the log MUST NOT accept any
+submission until it has verified that the submitted certificate or
+precertificate has a valid signature chain to an accepted trust anchor, using
+only the chain of intermediate CA certificates provided by the submitter.
+
+Logs SHOULD accept certificates and precertificates that are fully valid
+according to RFC 5280 [RFC5280] verification rules and are submitted with such
+a chain (A log may decide, for example, to temporarily reject valid submissions
+to protect itself against denial-of-service attacks).
 
 Logs MAY accept certificates and precertificates that have expired, are not yet
 valid, have been revoked, or are otherwise not fully valid according to RFC


### PR DESCRIPTION
To avoid policy discussions in an RFC:
* Indicate that log operators should not impose conditions on accessing
the log, but do not require it strongly (this requirement is not
essential to the operation of the protocol).
* Clarify exactly what are logs expected to accept for spam mitigation
(this is needed to guarantee that log clients find what they expect in
the log).