### PR TITLE
Issue #79 revisited - Precertificate signature must be over something other than just the TBSCertificate

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -649,11 +649,11 @@ following requirements:
 
 As described in Section 5.3 of [RFC5652], the `SignerInfo.signedAttrs` field
 MUST be present (because the `eContentType` is not `id-data`) and MUST contain
-at least a content-type attribute and a message-digest attribute. This field is
-included in the message digest calculation process (see Section 5.4 of
-[RFC5652]), which ensures that the `signature` in the CMS object will not be a
-valid X.509v3 signature and so cannot be used to construct a certificate from
-the precertificate.
+a content-type attribute and a message-digest attribute. This field is included
+in the message digest calculation process (see Section 5.4 of [RFC5652]), which
+ensures that the `signature` in the CMS object will not be a valid X.509v3
+signature and so cannot be used to construct a certificate from the
+precertificate.
 
 # Log Format and Operation
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -643,6 +643,8 @@ following requirements:
   is considered binding (i.e., misissuance of the precertificate is considered
   equivalent to misissuance of the corresponding certificate).
 
+* `SignerInfo.SignerIdentifier` MUST use the `subjectKeyIdentifier` option.
+
 * `SignedData.certificates` SHOULD be omitted.
 
 As described in Section 5.3 of [RFC5652], the `SignerInfo.signedAttrs` field

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -647,13 +647,20 @@ following requirements:
 
 * `SignedData.certificates` SHOULD be omitted.
 
-As described in Section 5.3 of [RFC5652], the `SignerInfo.signedAttrs` field
-MUST be present (because the `eContentType` is not `id-data`) and MUST contain
-a content-type attribute and a message-digest attribute. This field is included
-in the message digest calculation process (see Section 5.4 of [RFC5652]), which
-ensures that the `signature` in the CMS object will not be a valid X.509v3
-signature and so cannot be used to construct a certificate from the
-precertificate.
+Since the `eContentType` is not `id-data`, the `SignerInfo.signedAttrs` field
+MUST be present (see Section 5.3 of [RFC5652]) and MUST contain:
+
+* A content-type attribute whose value is the same as
+  `SignedData.encapContentInfo.eContentType`.
+  
+* A message-digest attribute whose value is the message digest of
+  `SignedData.encapContentInfo.eContent`.
+
+`SignerInfo.signedAttrs` is included in the message digest calculation process
+(see Section 5.4 of [RFC5652]), which ensures that the `SignerInfo.signature`
+value will not be a valid X.509v3 signature that could be used in conjunction
+with the TBSCertificate (from `SignedData.encapContentInfo.eContent`) to
+construct a valid certificate.
 
 # Log Format and Operation
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -637,15 +637,14 @@ following requirements:
   that the Transparency Information ({{x509v3_transinfo_extension}}) extension
   MUST be omitted.
 
+* `SignedData.certificates` SHOULD be omitted.
+
 * `SignedData.signerInfos` MUST contain 1 `SignerInfo` with a `signature` from
   the same (root or intermediate) CA that will ultimately issue the certificate.
   This signature indicates the CA's intent to issue the certificate. This intent
   is considered binding (i.e., misissuance of the precertificate is considered
   equivalent to misissuance of the corresponding certificate).
-
-* `SignerInfo.SignerIdentifier` MUST use the `subjectKeyIdentifier` option.
-
-* `SignedData.certificates` SHOULD be omitted.
+  * `SignerInfo.sid` MUST use the `subjectKeyIdentifier` option.
 
 Since the `eContentType` is not `id-data`, the `SignerInfo.signedAttrs` field
 MUST be present (see Section 5.3 of [RFC5652]) and MUST contain:

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -630,6 +630,8 @@ following requirements:
 
 * It MUST be DER encoded.
 
+* `SignedData.version` MUST be v3(3).
+
 * `SignedData.encapContentInfo.eContentType` MUST be the OID 1.3.101.78.
 
 * `SignedData.encapContentInfo.eContent` MUST contain a TBSCertificate [RFC5280]
@@ -637,7 +639,9 @@ following requirements:
   that the Transparency Information ({{x509v3_transinfo_extension}}) extension
   MUST be omitted.
 
-* `SignedData.certificates` SHOULD be omitted.
+* `SignedData.certificates` MUST be omitted.
+
+* `SignedData.crls` MUST be omitted.
 
 * `SignedData.signerInfos` MUST contain 1 `SignerInfo` with a `signature` from
   the same (root or intermediate) CA that will ultimately issue the certificate.

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -637,15 +637,21 @@ following requirements:
   that the Transparency Information ({{x509v3_transinfo_extension}}) extension
   MUST be omitted.
 
-* `SignedData.signerInfos` MUST contain a signature from the same (root or
-  intermediate) CA that will ultimately issue the certificate. This signature
-  indicates the CA's intent to issue the certificate. This intent is considered
-  binding (i.e., misissuance of the precertificate is considered equivalent to
-  misissuance of the certificate). (Note that, because of the structure of CMS,
-  the signature on the CMS object will not be a valid X.509v3 signature and so
-  cannot be used to construct a certificate from the precertificate).
+* `SignedData.signerInfos` MUST contain 1 `SignerInfo` with a `signature` from
+  the same (root or intermediate) CA that will ultimately issue the certificate.
+  This signature indicates the CA's intent to issue the certificate. This intent
+  is considered binding (i.e., misissuance of the precertificate is considered
+  equivalent to misissuance of the corresponding certificate).
 
 * `SignedData.certificates` SHOULD be omitted.
+
+As described in Section 5.3 of [RFC5652], the `SignerInfo.signedAttrs` field
+MUST be present (because the `eContentType` is not `id-data`) and MUST contain
+at least a content-type attribute and a message-digest attribute. This field is
+included in the message digest calculation process (see Section 5.4 of
+[RFC5652]), which ensures that the `signature` in the CMS object will not be a
+valid X.509v3 signature and so cannot be used to construct a certificate from
+the precertificate.
 
 # Log Format and Operation
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -79,7 +79,7 @@ normative:
   I-D.ietf-tls-tls13:
 
 informative:
-  RFC4634:
+  RFC6234:
   RFC5226:
   RFC6962:
   RFC6979:
@@ -1894,14 +1894,14 @@ CachedInformationType Values" registry that was defined in [RFC7924].
 IANA is asked to establish a registry of hash algorithm values, named
 "CT Hash Algorithms", that initially consists of:
 
-|-------------+----------------+------------------------------------------|
-| Value       | Hash Algorithm | Reference / Assignment Policy            |
-|-------------+----------------+------------------------------------------|
-| 0x00        | SHA-256        | [RFC4634]                                |
-| 0x01 - 0xDF | Unassigned     | Specification Required and Expert Review |
-| 0xE0 - 0xEF | Reserved       | Experimental Use                         |
-| 0xF0 - 0xFF | Reserved       | Private Use                              |
-|-------------+----------------+------------------------------------------|
+|-------------+----------------+------------------------+------------------------------------------|
+| Value       | Hash Algorithm | OID                    | Reference / Assignment Policy            |
+|-------------+----------------+------------------------|------------------------------------------|
+| 0x00        | SHA-256        | 2.16.840.1.101.3.4.2.1 | [RFC6234]                                |
+| 0x01 - 0xDF | Unassigned     |                        | Specification Required and Expert Review |
+| 0xE0 - 0xEF | Reserved       |                        | Experimental Use                         |
+| 0xF0 - 0xFF | Reserved       |                        | Private Use                              |
+|-------------+----------------+------------------------+------------------------------------------|
 
 ### Expert Review guidelines
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -626,36 +626,45 @@ not incorporated in the issued certificate is when a CA sends the precertificate
 to multiple logs, but only incorporates the SCTs that are returned first.
 
 A precertificate is a CMS [RFC5652] `signed-data` object that conforms to the
-following requirements:
+following profile:
 
 * It MUST be DER encoded.
 
 * `SignedData.version` MUST be v3(3).
 
-* `SignedData.encapContentInfo.eContentType` MUST be the OID 1.3.101.78.
+* `SignedData.digestAlgorithms` MUST only include the
+  `SignerInfo.digestAlgorithm` OID value (see below).
 
-* `SignedData.encapContentInfo.eContent` MUST contain a TBSCertificate [RFC5280]
-  that will be identical to the TBSCertificate in the issued certificate, except
-  that the Transparency Information ({{x509v3_transinfo_extension}}) extension
-  MUST be omitted.
+* `SignedData.encapContentInfo`:
+  * `eContentType` MUST be the OID 1.3.101.78.
+  * `eContent` MUST contain a TBSCertificate [RFC5280] that will be identical to
+    the TBSCertificate in the issued certificate, except that the Transparency
+    Information ({{x509v3_transinfo_extension}}) extension MUST be omitted.
 
 * `SignedData.certificates` MUST be omitted.
 
 * `SignedData.crls` MUST be omitted.
 
-* `SignedData.signerInfos` MUST contain 1 `SignerInfo` with a `signature` from
-  the same (root or intermediate) CA that will ultimately issue the certificate.
-  This signature indicates the CA's intent to issue the certificate. This intent
-  is considered binding (i.e., misissuance of the precertificate is considered
-  equivalent to misissuance of the corresponding certificate).
-  * `SignerInfo.sid` MUST use the `subjectKeyIdentifier` option.
+* `SignedData.signerInfos` MUST contain one `SignerInfo`:
+  * `version` MUST be v3(3).
+  * `sid` MUST use the `subjectKeyIdentifier` option.
+  * `digestAlgorithm` MUST be one of the hash algorithm OIDs listed in
+    {{hash_algorithms}}.
+  * `signedAttrs` MUST be present (see below).
+  * `signatureAlgorithm` MUST be the same OID as `TBSCertificate.signature`.
+  * `signature` MUST be from the same (root or intermediate) CA that will
+    ultimately issue the certificate. This signature indicates the CA's intent
+    to issue the certificate. This intent is considered binding (i.e.,
+    misissuance of the precertificate is considered equivalent to misissuance of
+    the corresponding certificate).
+  * `unsignedAttrs` MUST be omitted.
 
 Since the `eContentType` is not `id-data`, the `SignerInfo.signedAttrs` field
 MUST be present (see Section 5.3 of [RFC5652]) and MUST contain:
 
 * A content-type attribute whose value is the same as
   `SignedData.encapContentInfo.eContentType`.
-  
+
 * A message-digest attribute whose value is the message digest of
   `SignedData.encapContentInfo.eContent`.
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -650,7 +650,11 @@ following profile:
   * `sid` MUST use the `subjectKeyIdentifier` option.
   * `digestAlgorithm` MUST be one of the hash algorithm OIDs listed in
     {{hash_algorithms}}.
-  * `signedAttrs` MUST be present (see below).
+  * `signedAttrs` MUST be present and MUST contain two attributes:
+    * A content-type attribute whose value is the same as
+      `SignedData.encapContentInfo.eContentType`.
+    * A message-digest attribute whose value is the message digest of
+      `SignedData.encapContentInfo.eContent`.
   * `signatureAlgorithm` MUST be the same OID as `TBSCertificate.signature`.
   * `signature` MUST be from the same (root or intermediate) CA that will
     ultimately issue the certificate. This signature indicates the CA's intent
@@ -658,15 +662,6 @@ following profile:
     misissuance of the precertificate is considered equivalent to misissuance of
     the corresponding certificate).
   * `unsignedAttrs` MUST be omitted.
-
-Since the `eContentType` is not `id-data`, the `SignerInfo.signedAttrs` field
-MUST be present (see Section 5.3 of [RFC5652]) and MUST contain:
-
-* A content-type attribute whose value is the same as
-  `SignedData.encapContentInfo.eContentType`.
-
-* A message-digest attribute whose value is the message digest of
-  `SignedData.encapContentInfo.eContent`.
 
 `SignerInfo.signedAttrs` is included in the message digest calculation process
 (see Section 5.4 of [RFC5652]), which ensures that the `SignerInfo.signature`


### PR DESCRIPTION
Explain how a precertificate signature cannot be a certificate signature.
Draw attention to the RFC5652 requirement to include the 'signedAttrs' field.