### PR TITLE
Adding licensing information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement. You (or your employer) retain the copyright to your contribution,
+this simply gives us permission to use and redistribute your contributions as
+part of the project. Head over to <https://cla.developers.google.com/> to see
+your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+# Contributing
+
+This repository relates to activities in the Internet Engineering Task Force
+([IETF](https://www.ietf.org/)). All material in this repository is considered
+Contributions to the IETF Standards Process, as defined in the intellectual
+property policies of IETF currently designated as
+[BCP 78](https://www.rfc-editor.org/info/bcp78),
+[BCP 79](https://www.rfc-editor.org/info/bcp79) and the
+[IETF Trust Legal Provisions (TLP) Relating to IETF Documents](http://trustee.ietf.org/trust-legal-provisions.html).
+
+Any edit, commit, pull request, issue, comment or other change made to this
+repository constitutes Contributions to the IETF Standards Process
+(https://www.ietf.org/).
+
+You agree to comply with all applicable IETF policies and procedures, including,
+BCP 78, 79, the TLP, and the TLP rules regarding code components (e.g. being
+subject to a Simplified BSD License) in Contributions.
+
+
+## Other Resources
+
+Discussion of this work occurs on the
+[{WG_NAME} working group mailing list](https://mailarchive.ietf.org/arch/browse/{WG_NAME}/)
+([subscribe](https://www.ietf.org/mailman/listinfo/{WG_NAME})).  In addition to
+contributions in github, you are encouraged to participate in discussions there.
+
+**Note**: Some working groups adopt a policy whereby substantive discussion of
+technical issues needs to occur on the mailing list.
+
+You might also like to familiarize yourself with other
+[working group documents](https://datatracker.ietf.org/wg/{WG_NAME}/documents/).


### PR DESCRIPTION
Clarify this repo's licensing by adding the text from the IETF
recommended boilerplate to the LICENSE file (see
https://github.com/martinthomson/i-d-template/blob/master/template/CONTRIBUTING.md).

Contributions are governed by the Google requirements as set
out in the CONTRIBUTING.md file.