### PR TITLE
A-D review: MUSTs -> SHOULDs.

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -753,11 +753,11 @@ elements.
 
 ## Accepting Submissions
 
-To avoid being overloaded by invalid submissions, the log MUST NOT accept any
+To avoid being overloaded by invalid submissions, the log SHOULD NOT accept any
 submission until it has verified that the certificate or precertificate was
 submitted with a valid signature chain to an accepted trust anchor. The log
-MUST NOT use other sources of intermediate CA certificates to attempt
-certification path construction; instead, it MUST only use the intermediate CA
+SHOULD NOT use other sources of intermediate CA certificates to attempt
+certification path construction; instead, it SHOULD only use the intermediate CA
 certificates provided in the submission, in the order provided.
 
 Logs SHOULD accept certificates and precertificates that are fully valid

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -756,8 +756,8 @@ elements.
 To avoid being overloaded by invalid submissions, the log SHOULD NOT accept any
 submission until it has verified that the certificate or precertificate was
 submitted with a valid signature chain to an accepted trust anchor. The log
-SHOULD NOT use other sources of intermediate CA certificates to attempt
-certification path construction; instead, it SHOULD only use the intermediate CA
+MUST NOT use other sources of intermediate CA certificates to attempt
+certification path construction; instead, it MUST only use the intermediate CA
 certificates provided in the submission, in the order provided.
 
 Logs SHOULD accept certificates and precertificates that are fully valid


### PR DESCRIPTION
EKR wrote "I'm not arguing that you shouldn't require submission of complete chains, I'm saying I don't understand why MUST verify is a conformance requirement."

I just chatted to @AlCutter, who convinced me that we should downgrade the MUSTs in this paragraph to SHOULDs.