### PR TITLE
A-D review: Re-addressing of the MUSTs->SHOUDLs.

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -753,10 +753,19 @@ elements.
 
 ## Accepting Submissions
 
-To avoid being overloaded by invalid submissions, the log MUST NOT accept any
-submission until it has verified that the certificate or precertificate was
-submitted with a valid signature chain to an accepted trust anchor. The log
-MUST NOT use other sources of intermediate CA certificates to attempt
+To set clear expectations for what monitors would find in a log, and to avoid
+avoid being overloaded by invalid submissions, the log MUST NOT accept any
+submission until it has verified that the certificate or precertificate
+submitted chains to an accepted trust anchor. While there are no security
+implications to a log accepting a submission that does not chain to one of its
+accepted trust anchors, it would put additional burden on clients and monitors
+to inspect log entries. Additionally, there are no provisions in the protocol
+for a long to indicate a particular entry was erroneously admitted. For these
+reasons, under no circumstances, should an implementation of a log according
+to this protocol admit a submission into the log without positively verifying
+that the submission chains to one of the log's accepted trust anchors.
+
+The log MUST NOT use other sources of intermediate CA certificates to attempt
 certification path construction; instead, it MUST only use the intermediate CA
 certificates provided in the submission, in the order provided.
 


### PR DESCRIPTION
Elaborate on why, despite not having any security implications, it is
not wise to allow log implementations to admit submissions that do not
chain to a trusted root anchor.

Note the phrase "with a valid signature chain" was omitted, as the
following paragraph deals with it.

It should be clear that the MUST in this paragraph is to guide
implementations to never admit submissions that do not chain to an
accepted trust anchor - while implementations may have bugs with that
result, the option to admit such submissions is not at the
implementation's discretion (using a SHOULD would imply that it is,
under certain circumstances. a MUST clearly indicates it is not).

Hopefully this clarification and the removal of the wording about valid
signature chains makes it clear that the MUST is intended to guide
implementations in case of submissions not chaining to an accepted trust
anchor.