### PR TITLE
Clarify why submissions must chain to an accepted trust anchor.

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -753,10 +753,16 @@ elements.
 
 ## Accepting Submissions
 
-To avoid being overloaded by invalid submissions, the log MUST NOT accept any
-submission until it has verified that the certificate or precertificate was
-submitted with a valid signature chain to an accepted trust anchor. The log
-MUST NOT use other sources of intermediate CA certificates to attempt
+To set clear expectations for what monitors would find in a log, and to avoid
+being overloaded by invalid submissions, the log MUST NOT accept any submission
+until it has verified that the submitted certificate or precertificate chains to
+an accepted trust anchor. While there are no security implications to a log
+accepting a submission that does not chain to one of its accepted trust anchors,
+doing so would put additional burden on monitors that inspect log entries.
+Additionally, there are no provisions in the protocol for a log to indicate that
+a particular submission was erroneously accepted.
+
+The log MUST NOT use other sources of intermediate CA certificates to attempt
 certification path construction; instead, it MUST only use the intermediate CA
 certificates provided in the submission, in the order provided.
 


### PR DESCRIPTION
This PR, which replace #289, incorporates Eran's text from #293 with Al's and my comments.  I'm going to merge it without waiting for the usual approvals, in order to get an updated I-D submitted before today's I-D submission deadline.