### PR TITLE
A-D review: Remove the Preventing Tracking Clients section.

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -2113,19 +2113,6 @@ issued too closely together, proving violation of the STH issuance rate limit;
 or an STH with a root hash that does not match the one calculated from a copy of
 the log, proving violation of the append-only property.
 
-## Preventing Tracking Clients {#prevent_tracking_clients}
-
-Clients that gossip STHs or report back SCTs can be tracked or traced if a log
-produces multiple STHs or SCTs with the same timestamp and data but different
-signatures. Logs SHOULD mitigate this risk by either:
-
-- Using deterministic signature schemes, or
-
-- Producing no more than one SCT for each distinct submission and no more than one
-STH for each distinct tree_size. Each of these SCTs and STHs can be stored by
-the log and served to other clients that submit the same certificate or request
-the same STH.
-
 ## Multiple SCTs {#requiring_multiple_scts}
 
 By requiring TLS servers to offer multiple SCTs, each from a different log, TLS


### PR DESCRIPTION
EKR wrote:
`I think "tracked or traced" by who.  As far as a deterministic scheme, that seems like a wg decision, but what would be the implication for RSA-PSS?`

Eran, Al and I discussed this.  Al wrote...
`I don't think this document should be talking about this at all; this seems like a concession to a gossip design which hasn't yet been experimented with, built, or standardised...
Would this section not better live in whatever gossip docs which build upon -bis, where it's important for that model's security/privacy guarantees?`
...and then we agreed to remove this section.