### PR TITLE
A-D review: Remove the 'no security implications' claim

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -753,14 +753,11 @@ elements.
 
 ## Accepting Submissions
 
-To set clear expectations for what monitors would find in a log, and to avoid
-being overloaded by invalid submissions, the log MUST NOT accept any submission
-until it has verified that the submitted certificate or precertificate chains to
-an accepted trust anchor. While there are no security implications to a log
-accepting a submission that does not chain to one of its accepted trust anchors,
-doing so would put additional burden on monitors that inspect log entries.
-Additionally, there are no provisions in the protocol for a log to indicate that
-a particular submission was erroneously accepted.
+To ensure that logged certificates and precertificates are attributable to a
+known trust anchor, and to set clear expectations for what monitors would find
+in a log, and to avoid being overloaded by invalid submissions, the log MUST NOT
+accept any submission until it has verified that the submitted certificate or
+precertificate chains to an accepted trust anchor.
 
 The log MUST NOT use other sources of intermediate CA certificates to attempt
 certification path construction; instead, it MUST only use the intermediate CA


### PR DESCRIPTION
Implement the changes suggested by Andrew Ayer in this message to the TRANS list:
https://mailarchive.ietf.org/arch/msg/trans/wNYK7FNbWDNqoTpPO0u1HsJOpSc