### PR TITLE
Switch intended status of 6962-bis from Standards Track to Experimental.

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -2,7 +2,7 @@
 title: "Certificate Transparency Version 2.0"
 docname: draft-ietf-trans-rfc6962-bis-29
 obsoletes: 6962
-category: "std"
+category: exp
 
 ipr: "trust200902"
 area: Security


### PR DESCRIPTION
As per discussion with the TRANS Chairs, Security A-Ds, and the other 6962-bis authors.