### PR TITLE
Fix idnits in -29

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -46,12 +46,12 @@ normative:
   RFC5652:
   RFC6066:
   RFC6960:
-  RFC7159:
   RFC7231:
   RFC7633:
   RFC7807:
   RFC7924:
   RFC8032:
+  RFC8259:
   RFC8446:
   HTML401:
     target: http://www.w3.org/TR/1999/REC-html401-19991224
@@ -1119,7 +1119,7 @@ To avoid that, the following actions are suggested:
 # Log Client Messages {#client_messages}
 
 Messages are sent as HTTPS GET or POST requests. Parameters for POSTs and all
-responses are encoded as JavaScript Object Notation (JSON) objects [RFC7159].
+responses are encoded as JavaScript Object Notation (JSON) objects [RFC8259].
 Parameters for GETs are encoded as order-independent key/value URL parameters,
 using the "application/x-www-form-urlencoded" format described in the "HTML 4.01
 Specification" [HTML401]. Binary data is base64 encoded [RFC4648] as specified

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -133,6 +133,9 @@ intent is that eventually clients would refuse to honor certificates that do not
 appear in a log, effectively forcing CAs to add all issued certificates to the
 logs.
 
+This document obsoletes RFC 6962.  It also specifies a new TLS extension that is
+used to send various CT log artifacts.
+
 Logs are network services that implement the protocol operations for submissions
 and queries that are defined in this document.
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -83,10 +83,10 @@ normative:
 
 informative:
   RFC6234:
-  RFC5226:
   RFC6962:
   RFC6979:
   RFC7320:
+  RFC8126:
   I-D.ietf-trans-gossip:
   CrosbyWallach:
     target: http://static.usenix.org/event/sec09/tech/full_papers/crosby.pdf
@@ -1920,7 +1920,7 @@ instead.
 # IANA Considerations
 
 The assignment policy criteria mentioned in this section refer to the policies
-outlined in [RFC5226].
+outlined in [RFC8126].
 
 ## New Entry to the TLS ExtensionType Registry
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -46,7 +46,6 @@ normative:
   RFC5652:
   RFC6066:
   RFC6960:
-  RFC6961:
   RFC7159:
   RFC7231:
   RFC7633:
@@ -1554,11 +1553,6 @@ Three mechanisms are provided because they have different tradeoffs.
   subsequently consider the certificate to be non-compliant and in need of
   re-issuance.
 
-Additionally, a TLS server which supports presenting SCTs using an OCSP response
-MAY provide it when the TLS client included the `status_request_v2` extension
-([RFC6961]) in the (extended) `ClientHello`, but only in addition to at least
-one of the three mechanisms listed above.
-
 ## Multiple SCTs {#multiple-scts}
 
 CT-using TLS servers SHOULD send SCTs from multiple logs, because:
@@ -1713,8 +1707,7 @@ implementation-dependent (see, for example, [Chromium.Policy]).
 
 TLS clients receive SCTs and inclusion proofs alongside or in certificates.
 CT-using TLS clients MUST implement all of the three mechanisms by which TLS
-servers may present SCTs (see {{tls_servers}}) and MAY also accept SCTs via the
-`status_request_v2` extension ([RFC6961]).
+servers may present SCTs (see {{tls_servers}}).
 
 TLS clients that support the `transparency_info` TLS extension
 (see {{tls_transinfo_extension}}) SHOULD include it in ClientHello messages,


### PR DESCRIPTION
This PR addresses the issues with https://www.ietf.org/id/draft-ietf-trans-rfc6962-bis-29.txt found by https://tools.ietf.org/tools/idnits/.  Here is the idnits output, with comments inline...

```
idnits 2.16.0 

tmp/draft-ietf-trans-rfc6962-bis-29.txt:
tmp/draft-ietf-trans-rfc6962-bis-29.txt(380): Unexpected reference format: '...  {d'[0] = d[...'
tmp/draft-ietf-trans-rfc6962-bis-29.txt(465): Unexpected reference format: '...0, {d[0]}) = ...'
```
Nothing to fix.  It seems unlikely that readers of this document will think that these [ ] brackets denote references.
```
tmp/draft-ietf-trans-rfc6962-bis-29.txt(775): Found possible IPv4 address '1.3.101.78' in position 41; this doesn't match the suggested documentation address ranges specified in RFC 6890 (or successor): blocks 192.0.2.0/24 (TEST-NET-1), 198.51.100.0/24 (TEST-NET-2), and 203.0.113.0/24 (TEST-NET-3); or the 233.252.0.0/24 (MCAST-TEST-NET) example multicast address range specified in RFC 5771.
tmp/draft-ietf-trans-rfc6962-bis-29.txt(2060): Found possible IPv4 address '1.3.101.75' in position 4; this doesn't match the suggested documentation address ranges specified in RFC 6890 (or successor): blocks 192.0.2.0/24 (TEST-NET-1), 198.51.100.0/24 (TEST-NET-2), and 203.0.113.0/24 (TEST-NET-3); or the 233.252.0.0/24 (MCAST-TEST-NET) example multicast address range specified in RFC 5771.
tmp/draft-ietf-trans-rfc6962-bis-29.txt(2640): Found possible IPv4 address '1.3.101.8192' in position 6; this doesn't match the suggested documentation address ranges specified in RFC 6890 (or successor): blocks 192.0.2.0/24 (TEST-NET-1), 198.51.100.0/24 (TEST-NET-2), and 203.0.113.0/24 (TEST-NET-3); or the 233.252.0.0/24 (MCAST-TEST-NET) example multicast address range specified in RFC 5771.
tmp/draft-ietf-trans-rfc6962-bis-29.txt(2641): Found possible IPv4 address '1.3.101.16383' in position 6; this doesn't match the suggested documentation address ranges specified in RFC 6890 (or successor): blocks 192.0.2.0/24 (TEST-NET-1), 198.51.100.0/24 (TEST-NET-2), and 203.0.113.0/24 (TEST-NET-3); or the 233.252.0.0/24 (MCAST-TEST-NET) example multicast address range specified in RFC 5771.
tmp/draft-ietf-trans-rfc6962-bis-29.txt(2644): Found possible IPv4 address '1.3.101.80' in position 6; this doesn't match the suggested documentation address ranges specified in RFC 6890 (or successor): blocks 192.0.2.0/24 (TEST-NET-1), 198.51.100.0/24 (TEST-NET-2), and 203.0.113.0/24 (TEST-NET-3); or the 233.252.0.0/24 (MCAST-TEST-NET) example multicast address range specified in RFC 5771.
tmp/draft-ietf-trans-rfc6962-bis-29.txt(2647): Found possible IPv4 address '1.3.101.8192' in position 31; this doesn't match the suggested documentation address ranges specified in RFC 6890 (or successor): blocks 192.0.2.0/24 (TEST-NET-1), 198.51.100.0/24 (TEST-NET-2), and 203.0.113.0/24 (TEST-NET-3); or the 233.252.0.0/24 (MCAST-TEST-NET) example multicast address range specified in RFC 5771.
tmp/draft-ietf-trans-rfc6962-bis-29.txt(2651): Found possible IPv4 address '1.3.101.80' in position 8; this doesn't match the suggested documentation address ranges specified in RFC 6890 (or successor): blocks 192.0.2.0/24 (TEST-NET-1), 198.51.100.0/24 (TEST-NET-2), and 203.0.113.0/24 (TEST-NET-3); or the 233.252.0.0/24 (MCAST-TEST-NET) example multicast address range specified in RFC 5771.
```
Nothing to fix.  These are OIDs, not IP Addresses.
```
  Checking boilerplate required by RFC 5378 and the IETF Trust (see
  https://trustee.ietf.org/license-info):
  ----------------------------------------------------------------------------

     No issues found here.

  Checking nits according to https://www.ietf.org/id-info/1id-guidelines.txt:
  ----------------------------------------------------------------------------

     No issues found here.

  Checking nits according to https://www.ietf.org/id-info/checklist :
  ----------------------------------------------------------------------------

  == There are 7 instances of lines with non-RFC6890-compliant IPv4 addresses
     in the document.  If these are example addresses, they should be changed.
```
As noted above, these are OIDs, not IP Addresses.
```
  -- The draft header indicates that this document obsoletes RFC6962, but the
     abstract doesn't seem to mention this, which it should.
```
Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/a45b753c62135fc3cfcaaaa44e3e36b5b191faa8
```
  Miscellaneous warnings:
  ----------------------------------------------------------------------------

  -- The document date (October 22, 2018) is 11 days in the past.  Is this
     intentional?
```
Nothing to fix.
```
  Checking references for intended status: Experimental
  ----------------------------------------------------------------------------

  -- Looks like a reference, but probably isn't: '0' on line 459
     'Given an ordered list of n inputs to the tree, D_n = {d[0], d[1],...'

  -- Looks like a reference, but probably isn't: '1' on line 459
     'Given an ordered list of n inputs to the tree, D_n = {d[0], d[1],...'

  -- Looks like a reference, but probably isn't: '7' on line 608
     'The consistency proof between hash2 and hash is PROOF(6, D[7]) =...'
```
As noted above, it seems unlikely that readers of this document will think that these [ ] brackets denote references.
```
  ** Obsolete normative reference: RFC 6961 (Obsoleted by RFC 8446)
```
Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/80de002300a5490f1ff93b1271506c089c9ceb3f.  Since `status_request_v2` is deprecated in TLS 1.3 and hasn't seen much (if any!) deployment in TLS<=1.2, I've proposed that we drop support for it in 6962-bis.
```
  ** Obsolete normative reference: RFC 7159 (Obsoleted by RFC 8259)
```
Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/06d688c2ffdbe48db04732b63812ab9af8fec270
```
  -- Obsolete informational reference (is this intentional?): RFC 5226
     (Obsoleted by RFC 8126)
```
Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/e2c9fd26e3fd9a89c8153a14779c1264c698c39b
```
     Summary: 2 errors (**), 0 flaws (~~), 1 warning (==), 6 comments (--).
```