### PR TITLE
Remove stray reference to status_request_v2.

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -255,10 +255,8 @@ community. The major changes are:
 - CT TLS extension: the `signed_certificate_timestamp` TLS extension has been
   replaced by the `transparency_info` TLS extension.
 
-- Other TLS extensions: `status_request_v2` may be used (in the same
-  manner as `status_request`); `cached_info` may be used to avoid sending the
-  same complete SCTs and inclusion proofs to the same TLS clients multiple
-  times.
+- Other TLS extensions: `cached_info` may be used to avoid sending the same
+  complete SCTs and inclusion proofs to the same TLS clients multiple times.
 
 - Verification algorithms: added detailed algorithms for verifying inclusion
   proofs, for verifying consistency between two STHs, and for verifying a root


### PR DESCRIPTION
We dropped support for status_request_v2 in https://github.com/google/certificate-transparency-rfcs/commit/e9b69e5d580fddd5860707a2cbe26004ceb58e57, but missed this mention of it in the "Major Differences from CT 1.0" section.