### PR TITLE
IESG Last Call: Address Alissa Cooper's DISCUSS and COMMENT feedback

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -50,6 +50,7 @@ normative:
   RFC7633:
   RFC7807:
   RFC8032:
+  RFC8174:
   RFC8259:
   RFC8446:
   HTML401:
@@ -195,8 +196,9 @@ such mechanisms are outside the scope of this document.
 ## Requirements Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC2119].
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
+when, and only when, they appear in all capitals, as shown here.
 
 ## Data Structures {#data_structures}
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -1958,14 +1958,18 @@ the log.
 IANA is asked to establish a registry of signature algorithm values, named
 "CT Signature Algorithms", that initially consists of:
 
-|--------------------------------+----------------------------------------------------+--------------------------------|
-| SignatureScheme Value          | Signature Algorithm                                | Reference / Assignment Policy  |
-|--------------------------------+----------------------------------------------------+--------------------------------|
-| ecdsa_secp256r1_sha256(0x0403) | ECDSA (NIST P-256) with SHA-256                    | [FIPS186-4]                    |
-| ecdsa_secp256r1_sha256(0x0403) | Deterministic ECDSA (NIST P-256) with HMAC-SHA256  | [RFC6979]                      |
-| ed25519(0x0807)                | Ed25519 (PureEdDSA with the edwards25519 curve)    | [RFC8032]                      |
-| private_use(0xFE00..0xFFFF)    | Reserved                                           | Private Use                    |
-|--------------------------------+----------------------------------------------------+--------------------------------|
+|--------------------------------+----------------------------------------------------+-------------------------------|
+| SignatureScheme Value          | Signature Algorithm                                | Reference / Assignment Policy |
+|--------------------------------+----------------------------------------------------+-------------------------------|
+| 0x0000 - 0x0402                | Unassigned                                         | Expert Review                 |
+| ecdsa_secp256r1_sha256(0x0403) | ECDSA (NIST P-256) with SHA-256                    | [FIPS186-4]                   |
+| ecdsa_secp256r1_sha256(0x0403) | Deterministic ECDSA (NIST P-256) with HMAC-SHA256  | [RFC6979]                     |
+| 0x0404 - 0x0806                | Unassigned                                         | Expert Review                 |
+| ed25519(0x0807)                | Ed25519 (PureEdDSA with the edwards25519 curve)    | [RFC8032]                     |
+| 0x0808 - 0xFDFF                | Unassigned                                         | Expert Review                 |
+| 0xFE00 - 0xFEFF                | Reserved                                           | Experimental Use              |
+| 0xFF00 - 0xFFFF                | Reserved                                           | Private Use                   |
+|--------------------------------+----------------------------------------------------+-------------------------------|
 
 ### Expert Review guidelines
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -2048,12 +2048,12 @@ arc that was selected due to its short encoding.
 IANA is asked to establish a registry of Log IDs, named "CT Log ID Registry",
 that initially consists of:
 
-|------------------------------+------------+-------------------------------------------------|
-| Value                        | Log        | Reference / Assignment Policy                   |
-|------------------------------+------------+-------------------------------------------------|
-| 1.3.101.8192 - 1.3.101.16383 | Unassigned | Parameters Required and First Come First Served |
-| 1.3.101.80.0 - 1.3.101.80.*  | Unassigned | Parameters Required and First Come First Served |
-|------------------------------+------------+-------------------------------------------------|
+|------------------------------+--------------+------------+------------+-------------------------------|
+| Value                        | Log Base URL | Contact    | Owner      | Reference / Assignment Policy |
+|------------------------------+--------------+------------+------------+-------------------------------|
+| 1.3.101.8192 - 1.3.101.16383 | Unassigned   | Unassigned | Unassigned | First Come First Served       |
+| 1.3.101.80.0 - 1.3.101.80.*  | Unassigned   | Unassigned | Unassigned | First Come First Served       |
+|------------------------------+--------------+------------+------------+-------------------------------|
 
 All OIDs in the range from 1.3.101.8192 to 1.3.101.16383 have been reserved.
 This is a limited resource of 8,192 OIDs, each of which has an encoded length of
@@ -2063,8 +2063,12 @@ The 1.3.101.80 arc has been delegated. This is an unlimited resource, but only
 the 128 OIDs from 1.3.101.80.0 to 1.3.101.80.127 have an encoded length of only
 4 octets.
 
-Each application for the allocation of a Log ID should be accompanied by all of
-the required parameters (except for the Log ID) listed in {{log_parameters}}.
+Each application for the allocation of a Log ID MUST be accompanied by:
+* the Log's Base URL (see {{log_parameters}}).
+* a Contact (including contact information), from whom further information can
+  be obtained.
+* an Owner (including contact information), who is authorized to change this Log
+  ID allocation.
 
 # Security Considerations
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -1937,16 +1937,16 @@ document as the "Reference".
 IANA is asked to establish a registry of hash algorithm values, named
 "CT Hash Algorithms", that initially consists of:
 
-|-------------+----------------+------------------------+------------------------------------------|
-| Value       | Hash Algorithm | OID                    | Reference / Assignment Policy            |
-|-------------+----------------+------------------------|------------------------------------------|
-| 0x00        | SHA-256        | 2.16.840.1.101.3.4.2.1 | [RFC6234]                                |
-| 0x01 - 0xDF | Unassigned     |                        | Specification Required and Expert Review |
-| 0xE0 - 0xEF | Reserved       |                        | Experimental Use                         |
-| 0xF0 - 0xFF | Reserved       |                        | Private Use                              |
-|-------------+----------------+------------------------+------------------------------------------|
+|-------------+----------------+------------------------+-------------------------------|
+| Value       | Hash Algorithm | OID                    | Reference / Assignment Policy |
+|-------------+----------------+------------------------|-------------------------------|
+| 0x00        | SHA-256        | 2.16.840.1.101.3.4.2.1 | [RFC6234]                     |
+| 0x01 - 0xDF | Unassigned     |                        | Specification Required        |
+| 0xE0 - 0xEF | Reserved       |                        | Experimental Use              |
+| 0xF0 - 0xFF | Reserved       |                        | Private Use                   |
+|-------------+----------------+------------------------+-------------------------------|
 
-### Expert Review guidelines
+### Specification Required guidance
 
 The appointed Expert should ensure that the proposed algorithm has a public
 specification and is suitable for use as a cryptographic hash algorithm with no
@@ -1979,28 +1979,28 @@ cryptographic signature algorithm.
 IANA is asked to establish a registry of `VersionedTransType` values, named
 "CT VersionedTransTypes", that initially consists of:
 
-|-----------------+---------------------------+------------------------------------------|
-| Value           | Type and Version          | Reference / Assignment Policy            |
-|-----------------+---------------------------+------------------------------------------|
-| 0x0000          | Reserved                  | [RFC6962] (*)                            |
-| 0x0001          | x509_entry_v2             | RFCXXXX                                  |
-| 0x0002          | precert_entry_v2          | RFCXXXX                                  |
-| 0x0003          | x509_sct_v2               | RFCXXXX                                  |
-| 0x0004          | precert_sct_v2            | RFCXXXX                                  |
-| 0x0005          | signed_tree_head_v2       | RFCXXXX                                  |
-| 0x0006          | consistency_proof_v2      | RFCXXXX                                  |
-| 0x0007          | inclusion_proof_v2        | RFCXXXX                                  |
-| 0x0008 - 0xDFFF | Unassigned                | Specification Required and Expert Review |
-| 0xE000 - 0xEFFF | Reserved                  | Experimental Use                         |
-| 0xF000 - 0xFFFF | Reserved                  | Private Use                              |
-|-----------------+---------------------------+------------------------------------------|
+|-----------------+---------------------------+-------------------------------|
+| Value           | Type and Version          | Reference / Assignment Policy |
+|-----------------+---------------------------+-------------------------------|
+| 0x0000          | Reserved                  | [RFC6962] (*)                 |
+| 0x0001          | x509_entry_v2             | RFCXXXX                       |
+| 0x0002          | precert_entry_v2          | RFCXXXX                       |
+| 0x0003          | x509_sct_v2               | RFCXXXX                       |
+| 0x0004          | precert_sct_v2            | RFCXXXX                       |
+| 0x0005          | signed_tree_head_v2       | RFCXXXX                       |
+| 0x0006          | consistency_proof_v2      | RFCXXXX                       |
+| 0x0007          | inclusion_proof_v2        | RFCXXXX                       |
+| 0x0008 - 0xDFFF | Unassigned                | Specification Required        |
+| 0xE000 - 0xEFFF | Reserved                  | Experimental Use              |
+| 0xF000 - 0xFFFF | Reserved                  | Private Use                   |
+|-----------------+---------------------------+-------------------------------|
 
 (*) The 0x0000 value is reserved so that v1 SCTs are distinguishable from v2
 SCTs and other `TransItem` structures.
 
 \[RFC Editor: please update 'RFCXXXX' to refer to this document, once its RFC number is known.\]
 
-### Expert Review guidelines
+### Specification Required guidance
 
 The appointed Expert should review the public specification to ensure that it is
 detailed enough to ensure implementation interoperability.
@@ -2010,13 +2010,13 @@ detailed enough to ensure implementation interoperability.
 IANA is asked to establish a registry of `ExtensionType` values, named "CT Log
 Artifact Extensions", that initially consists of:
 
-|-----------------+------------+-----+------------------------------------------|
-| ExtensionType   | Status     | Use | Reference / Assignment Policy            |
-|-----------------+------------+-----+------------------------------------------|
-| 0x0000 - 0xDFFF | Unassigned | n/a | Specification Required and Expert Review |
-| 0xE000 - 0xEFFF | Reserved   | n/a | Experimental Use                         |
-| 0xF000 - 0xFFFF | Reserved   | n/a | Private Use                              |
-|-----------------+------------+-----+------------------------------------------|
+|-----------------+------------+-----+-------------------------------|
+| ExtensionType   | Status     | Use | Reference / Assignment Policy |
+|-----------------+------------+-----+-------------------------------|
+| 0x0000 - 0xDFFF | Unassigned | n/a | Specification Required        |
+| 0xE000 - 0xEFFF | Reserved   | n/a | Experimental Use              |
+| 0xF000 - 0xFFFF | Reserved   | n/a | Private Use                   |
+|-----------------+------------+-----+-------------------------------|
 
 The "Use" column should contain one or both of the following values:
 
@@ -2024,7 +2024,7 @@ The "Use" column should contain one or both of the following values:
 
 * "STH", for extensions specified for use in Signed Tree Heads.
 
-### Expert Review guidelines
+### Specification Required guidance
 
 The appointed Expert should review the public specification to ensure that it is
 detailed enough to ensure implementation interoperability. The Expert should


### PR DESCRIPTION
> On 13th March 2019, Alissa Cooper wrote:
> Glad to see this revision of the protocol. My comments and questions should be easy to address.
> 
> = Section 10.2, 10.4, 10.5 =
> 
> A Specification Required registry policy implies expert review. So a registry policy of "Specification Required and Expert Review" is duplicative; it should just say "Specification Required." I know this seems trivial but there has been so much confusion about this through the years that it is important to be precise.

Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/0a21e8c769bc8d5c0d28bb4c610175476187478a

> = Section 10.3 =
> 
> This section needs to state what the registry policy is for the code points not already registered (presumably Expert Review given 10.3.1, but it needs to be explicit).

Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/7cd3471548c903fd891a99227bf081ca51939470

> = Section 10.6.1 =
> 
> Using the term "Parameters Required" as a capitalized term is confusing. FCFS registries by definition can require additional information to be provided in order to get something registered. For avoidance of confusion I think the assignment policy should be listed as First Come First Served and the requirement that parameters be included in the application can use a normative MUST in the last paragraph if there is concern that the parameters won't be supplied.

Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/704a71a18457b4558ce26fe4be519d6ea06a729a

> However, I also wonder what will be done with the parameters that are supplied. Is IANA expected to just maintain them privately, or to publish them?

On reflection, I think it makes little sense for IANA to handle most of these parameters, since some of them (e.g., Maximum Chain Length, Maximum Merge Delay, STH Frequency Count, Final STH) may change over time for operational reasons that really needn't concern IANA.  Therefore, this PR changes this registry to contain just the Log's Base URL, along with (as advised by https://tools.ietf.org/html/rfc8126#section-9.5) an Owner and Contact (from whom the other parameter values may be obtained).

> What is expected to appear in the 'Log' column in the registry?

Clarified as "Log's Base URL".

> In Section 1.1, please use the RFC 8174 boilerplate in lieu of the RFC 2119 boilerplate.

Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/efb1229cf290f88bbb80016268f77d2fd8193cca