### PR TITLE
IESG Last Call: Address Adam Roach's DISCUSS and COMMENT feedback

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -205,9 +205,9 @@ in Section 3 of [RFC8446].
 
 ## Major Differences from CT 1.0
 
-This document revises and obsoletes the experimental CT 1.0 [RFC6962] protocol,
-drawing on insights gained from CT 1.0 deployments and on feedback from the
-community. The major changes are:
+This document revises and obsoletes the CT 1.0 [RFC6962] protocol, drawing on
+insights gained from CT 1.0 deployments and on feedback from the community. The
+major changes are:
 
 - Hash and signature algorithm agility: permitted algorithms are now specified
   in IANA registries.

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -268,7 +268,7 @@ major changes are:
 
 The log uses a binary Merkle Hash Tree for efficient auditing. The hash
 algorithm used is one of the log's parameters (see {{log_parameters}}).
-We have established a registry of acceptable hash algorithms (see
+This document establishes a registry of acceptable hash algorithms (see
 {{hash_algorithms}}). Throughout this document, the hash algorithm in use is
 referred to as HASH and the size of its output in bytes as HASH_SIZE. The input
 to the Merkle Tree Hash is a list of data entries; these entries will be

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -45,6 +45,7 @@ normative:
   RFC5280:
   RFC5652:
   RFC6066:
+  RFC6570:
   RFC6960:
   RFC7231:
   RFC7633:
@@ -718,7 +719,11 @@ A log is defined by a collection of parameters, which are used by clients to
 communicate with the log and to verify log artifacts.
 
 Base URL:
-: The URL to substitute for \<log server> in {{client_messages}}.
+: The URL formed by populating the URL template [RFC6570]
+  "https://{host}/.well-known/ct/v2/{prefix}", where the `host` and `prefix`
+  fields are chosen by the log operator. The `host` field MUST consist of only
+  a domain name and optional port number, and each log's Base URL MUST NOT be
+  shared by any other log.
 
 Hash Algorithm:
 : The hash algorithm used for the Merkle Tree (see {{hash_algorithms}}).
@@ -1146,17 +1151,12 @@ using the "application/x-www-form-urlencoded" format described in the "HTML 4.01
 Specification" [HTML401]. Binary data is base64 encoded [RFC4648] as specified
 in the individual messages.
 
-Clients are configured with a base URL for a log and construct URLs for requests
-by appending suffixes to this base URL. This structure places some degree of
-restriction on how log operators can deploy these services, as noted in
-[RFC7320]. However, operational experience with version 1 of this protocol has
-not indicated that these restrictions are a problem in practice.
+Clients are configured with a log's Base URL (see {{log_parameters}}), and they
+construct URLs for requests by appending suffixes to this Base URL, as described
+in the subsections below.
 
 Note that JSON objects and URL parameters may contain fields not specified here.
 These extra fields SHOULD be ignored.
-
-The \<log server> prefix, which is one of the log's parameters, MAY include a
-path as well as a server name and a port.
 
 In practice, log servers may include multiple front-end machines. Since it is
 impractical to keep these machines in perfect sync, errors may occur that are
@@ -1190,7 +1190,7 @@ detail:
   processing the request, ideally with sufficient detail to enable the error to
   be rectified.
 
-e.g., In response to a request of `/ct/v2/get-entries?start=100&end=99`, the log
+e.g., In response to a request of `get-entries?start=100&end=99`, the log
 would return a `400 Bad Request` response code with a body similar to the
 following:
 
@@ -1220,7 +1220,7 @@ minimum time for the client to wait before retrying the request.
 
 ## Submit Entry to Log {#submit-entry}
 
-POST https://\<log server>/ct/v2/submit-entry
+POST https://{host}/.well-known/ct/v2/{prefix}/submit-entry
 
 Inputs:
 
@@ -1290,7 +1290,7 @@ embedded in the certificate).
 
 ## Retrieve Latest Signed Tree Head {#get-sth}
 
-GET https://\<log server>/ct/v2/get-sth
+GET https://{host}/.well-known/ct/v2/{prefix}/get-sth
 
 No inputs.
 
@@ -1302,7 +1302,7 @@ Outputs:
 
 ## Retrieve Merkle Consistency Proof between Two Signed Tree Heads {#get-sth-consistency}
 
-GET https://\<log server>/ct/v2/get-sth-consistency
+GET https://{host}/.well-known/ct/v2/{prefix}/get-sth-consistency
 
 Inputs:
 
@@ -1352,7 +1352,7 @@ output.
 
 ## Retrieve Merkle Inclusion Proof from Log by Leaf Hash {#get-proof-by-hash}
 
-GET https://\<log server>/ct/v2/get-proof-by-hash
+GET https://{host}/.well-known/ct/v2/{prefix}/get-proof-by-hash
 
 Inputs:
 
@@ -1395,7 +1395,7 @@ See {{verify_inclusion}} for an outline of how to use the `inclusion` output.
 
 ## Retrieve Merkle Inclusion Proof, Signed Tree Head and Consistency Proof by Leaf Hash {#get-all-by-hash}
 
-GET https://\<log server>/ct/v2/get-all-by-hash
+GET https://{host}/.well-known/ct/v2/{prefix}/get-all-by-hash
 
 Inputs:
 
@@ -1450,7 +1450,7 @@ output.
 
 ## Retrieve Entries and STH from Log {#get-entries}
 
-GET https://\<log server>/ct/v2/get-entries
+GET https://{host}/.well-known/ct/v2/{prefix}/get-entries
 
 Inputs:
 
@@ -1530,7 +1530,7 @@ Error codes:
 
 ## Retrieve Accepted Trust Anchors {#get-anchors}
 
-GET https://\<log server>/ct/v2/get-anchors
+GET https://{host}/.well-known/ct/v2/{prefix}/get-anchors
 
 No inputs.
 


### PR DESCRIPTION
> On 13th March 2019, Adam Roach wrote:
> Thanks to everyone who worked on updating this protocol to reflect experience
> gathered from the initial CT protocol. I have one blocking comment, and a small
> number of editorial suggestions.
> 
> ---------------------------------------------------------------------------
> 
> §5:
> 
> >  Clients are configured with a base URL for a log and construct URLs
> >  for requests by appending suffixes to this base URL.  This structure
> >  places some degree of restriction on how log operators can deploy
> >  these services, as noted in [RFC7320].  However, operational
> >  experience with version 1 of this protocol has not indicated that
> >  these restrictions are a problem in practice.
> 
> The synthesis of URLs by a protocol in this fashion is prohibited by BCP 190:
> 
>    Scheme definitions define the presence, format, and semantics of a
>    path component in URIs; all other specifications MUST NOT constrain,
>    or define the structure or the semantics for any path component.
> 
> Unless the intention of this document is to update BCP 190 to change this
> normative requirement, we can't publish it in its current form. Note that doing
> so would require a change of venue, as updates to BCP 190 would not be covered
> by the current TRANS charter.
> 
> Please see BCP 190 section 3 for alternate approaches. All three approaches
> could be made to work for CT, and I would be happy to explain how to do so if
> clarification is desired.

Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/84998e6cb8ca5bd2c1c001b95ffdff7b0d63bb23

> §1.1:
> 
> >  The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
> >  "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
> >  document are to be interpreted as described in [RFC2119].
> 
> Consider using the boilerplate from RFC 8174.

Already addressed in PR #309.

> §1.3:
> 
> >  This document revises and obsoletes the experimental CT 1.0 [RFC6962]
> >  protocol, drawing on insights gained from CT 1.0 deployments and on
> >  feedback from the community.
> 
> Given that *this* document is also experimental, it seems a bit odd to call out
> RFC 6962 as experimental.

Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/36ceb2be02cf0c1dd5a3392a5a27894b196c140d

> §2.1.1:
> 
> >  We have established a registry of acceptable hash algorithms (see
> 
> The use of first person here is awkward. Consider: "This document
> establishes..."

Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/36e4ff467ac917d535fb6e7e0e7b209f5ac12668

> §10.2:
> 
> >  | 0x01 - | Unassigned |                        | Specification      |
> >  | 0xDF   |            |                        | Required and       |
> >  |        |            |                        | Expert Review      |
> 
> The policy being cited here is confusing. It is unclear whether the intention is
> that values can be registered under both §4.5 and §4.6 of RFC 8126. I suspect
> the intention here is the policy specified in RFC 8126 §4.6 only, without
> reference to the policy in §4.5. If so, please use the formal name
> "Specification Required."

Already addressed in PR #309.

> §10.4:
> 
> >  | 0x0008 -    | Unassigned           | Specification Required and   |
> >  | 0xDFFF      |                      | Expert Review                |
> 
> Same comment as above.

Already addressed in PR #309.

> §10.5:
> 
> >  | 0x0000 -      | Unassigned | n/a | Specification Required and     |
> >  | 0xDFFF        |            |     | Expert Review                  |
> 
> Same comment as above.

Already addressed in PR #309.