### PR TITLE
Clarify Base URL properties, and use <Base URL> instead of <log server> to define the client message URLs.

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -720,7 +720,11 @@ A log is defined by a collection of parameters, which are used by clients to
 communicate with the log and to verify log artifacts.
 
 Base URL:
-: The URL to substitute for \<log server> in {{client_messages}}.
+: The prefix used to construct URLs for client messages (see
+  {{client_messages}}). The base URL MUST be an "https" URL, MAY contain a port,
+  MAY contain a path with any number of path segments, but MUST NOT contain a
+  query string, fragment, or trailing "/".
+  Example: https://ct.example.org/blue
 
 Hash Algorithm:
 : The hash algorithm used for the Merkle Tree (see {{hash_algorithms}}).
@@ -1148,17 +1152,15 @@ using the "application/x-www-form-urlencoded" format described in the "HTML 4.01
 Specification" [HTML401]. Binary data is base64 encoded [RFC4648] as specified
 in the individual messages.
 
-Clients are configured with a base URL for a log and construct URLs for requests
-by appending suffixes to this base URL. This structure places some degree of
-restriction on how log operators can deploy these services, as noted in
-[RFC7320]. However, operational experience with version 1 of this protocol has
-not indicated that these restrictions are a problem in practice.
+Clients are configured with a log's base URL, which is one of the log's
+parameters. Clients construct URLs for requests by appending suffixes to this
+base URL. This structure places some degree of restriction on how log operators
+can deploy these services, as noted in [RFC7320]. However, operational
+experience with version 1 of this protocol has not indicated that these
+restrictions are a problem in practice.
 
 Note that JSON objects and URL parameters may contain fields not specified here.
 These extra fields SHOULD be ignored.
-
-The \<log server> prefix, which is one of the log's parameters, MAY include a
-path as well as a server name and a port.
 
 In practice, log servers may include multiple front-end machines. Since it is
 impractical to keep these machines in perfect sync, errors may occur that are
@@ -1192,9 +1194,9 @@ detail:
   processing the request, ideally with sufficient detail to enable the error to
   be rectified.
 
-e.g., In response to a request of `/ct/v2/get-entries?start=100&end=99`, the log
-would return a `400 Bad Request` response code with a body similar to the
-following:
+e.g., In response to a request of
+`<Base URL>/ct/v2/get-entries?start=100&end=99`, the log would return a
+`400 Bad Request` response code with a body similar to the following:
 
 ~~~~~~~~~~~
     {
@@ -1222,7 +1224,7 @@ minimum time for the client to wait before retrying the request.
 
 ## Submit Entry to Log {#submit-entry}
 
-POST https://\<log server>/ct/v2/submit-entry
+POST \<Base URL>/ct/v2/submit-entry
 
 Inputs:
 
@@ -1292,7 +1294,7 @@ embedded in the certificate).
 
 ## Retrieve Latest Signed Tree Head {#get-sth}
 
-GET https://\<log server>/ct/v2/get-sth
+GET \<Base URL>/ct/v2/get-sth
 
 No inputs.
 
@@ -1304,7 +1306,7 @@ Outputs:
 
 ## Retrieve Merkle Consistency Proof between Two Signed Tree Heads {#get-sth-consistency}
 
-GET https://\<log server>/ct/v2/get-sth-consistency
+GET \<Base URL>/ct/v2/get-sth-consistency
 
 Inputs:
 
@@ -1354,7 +1356,7 @@ output.
 
 ## Retrieve Merkle Inclusion Proof from Log by Leaf Hash {#get-proof-by-hash}
 
-GET https://\<log server>/ct/v2/get-proof-by-hash
+GET \<Base URL>/ct/v2/get-proof-by-hash
 
 Inputs:
 
@@ -1397,7 +1399,7 @@ See {{verify_inclusion}} for an outline of how to use the `inclusion` output.
 
 ## Retrieve Merkle Inclusion Proof, Signed Tree Head and Consistency Proof by Leaf Hash {#get-all-by-hash}
 
-GET https://\<log server>/ct/v2/get-all-by-hash
+GET \<Base URL>/ct/v2/get-all-by-hash
 
 Inputs:
 
@@ -1452,7 +1454,7 @@ output.
 
 ## Retrieve Entries and STH from Log {#get-entries}
 
-GET https://\<log server>/ct/v2/get-entries
+GET \<Base URL>/ct/v2/get-entries
 
 Inputs:
 
@@ -1532,7 +1534,7 @@ Error codes:
 
 ## Retrieve Accepted Trust Anchors {#get-anchors}
 
-GET https://\<log server>/ct/v2/get-anchors
+GET \<Base URL>/ct/v2/get-anchors
 
 No inputs.
 


### PR DESCRIPTION
This PR addresses feedback on the TRANS list from James @manger:
https://mailarchive.ietf.org/arch/msg/trans/jT9CajEdKQB3R9BdozYTYfceIyw
