### PR TITLE
IEST Last Call: Address Mirja Kühlewind's DISCUSS and COMMENT feedback

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -739,8 +739,8 @@ from the log.
 
 A log is defined by a collection of immutable parameters, which are used by
 clients to communicate with the log and to verify log artifacts. Except for the
-Final STH, each of these parameters MUST be established before the log operator
-begins to operate the log.
+Final Signed Tree Head (STH), each of these parameters MUST be established
+before the log operator begins to operate the log.
 
 Base URL:
 : The prefix used to construct URLs for client messages (see

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -2181,6 +2181,13 @@ By requiring TLS servers to offer multiple SCTs, each from a different log, TLS
 clients reduce the effectiveness of an attack where a CA and a log collude
 (see {{multiple-scts}}).
 
+## Leakage of DNS Information
+
+Malicious monitors can use logs to learn about the existence of domain names
+that might not otherwise be easy to discover. Some subdomain labels may reveal
+information about the service and software for which the subdomain is used,
+which in turn might facilitate targeted attacks.
+
 # Acknowledgements
 
 The authors would like to thank Erwann Abelea, Robin Alden, Andrew Ayer, Richard

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -2102,6 +2102,9 @@ registry, because these fields are immutable (see {{log_parameters}}).
 IANA is asked to accept requests from log operators to update their contact
 details in this registry.
 
+Since log operators can choose to not use this registry (see {{log_id}}), it is
+not expected to be a global directory of all logs.
+
 # Security Considerations
 
 With CAs, logs, and servers performing the actions described here, TLS clients


### PR DESCRIPTION
> There was a presentation at maprg IETF 103 about the question if CT helps
> attackers to find new domains. I think this risk should at least be mentioned
> in the security considerations section.

Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/3b2ec0a51f8abb4c8c0b985614fefa4291432dd9

>   1) I found section 2 a bit hard to follow. Would it maybe be possible to
>   provide more textual explanation of the algorithms instead of just describing
>   the steps of the algorithms? Also I was wondering how much much these
>   algorithms are actually „part“ of the protocol spec…? Are could these be
>   rather seen as example algorithms? Maybe that could be further clarified

We'll consider these comments on section 2 at a later date, along with Benjamin Kaduk's DISCUSS/COMMENT feedback on section 2.

>   2) Please expand STH on first occurrence (in sec 4.1)

Addressed by https://github.com/robstradling/certificate-transparency-rfcs/commit/d2d6b0ac303af2659e5df538391002f1bf454edb

>   3) Sec 4.4: „A log's operator MUST either allocate the OID
>      themselves or request an OID from the Log ID Registry (see
>      Section 10.6.1).“
> Isn't there an obligation to register?

The Log ID Registry is merely a source of OIDs that have short DER encodings.  A log operator may either (1) request an OID from the Log ID Registry, or (2) allocate an OID themselves (from an OID arc that they control, naturally).

The Registry is not intended to be a global directory of all logs.

>   4) sec 4.8: „If an
>     implementation sees an extension that it does not understand, it
>     SHOULD ignore that extension.“
> Maybe it’s just me because I may have missed some context but does „ignore“
> mean here that it should log it or not?

"It" (the precertificate or certificate) must have already been logged, because the corresponding SCT (that contains a potentially unrecognized extension) couldn't otherwise exist.

>   5) sec 5: „MAY retry the same
>     request without modification at a later date.“
> Would it be possible to provide a recommendation how long the client should
> wait?

The very next sentence in section 5 already specifies a mechanism for doing just that:
  'Note that as per
   [RFC7231], in the case of a 503 response the log MAY include a
   "Retry-After:" header in order to request a minimum time for the
   client to wait before retrying the request.'

>   6) sec 5.6: „Logs MAY restrict the number of entries that can be retrieved per
>     "get-entries" request.“
> Should this be added to sec 4.1?

I don't think that's a good idea.  I can imagine that operational issues might cause a log operator to want to vary this restriction at any time.

Clients should always be prepared to receive get-entries responses that contain fewer entries than they requested.

See also https://trac.ietf.org/trac/trans/ticket/95

>   7) sec 10.3: Couldn’t you use the TLS  SignatureScheme Registry directly
>   (instead of forming an own registry)?

It makes sense to synchronize the signature algorithm values we use with the TLS SignatureAlgorithm registry, because our data structures are defined according to the conventions laid out in the TLS RFC.

However, I don't think it's a good idea to use the TLS SignatureAlgorithm registry directly.  In 6962-bis, we've taken steps to make log artifacts smaller (compared to RFC6962); related to that, we've removed the option of logs being permitted to use RSA keys/signatures.  https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-16 permits RSA, and several other signature algorithms that we don't wish to permit or recommend (i.e. "anonymous", DSA, GOST, and "Reserved for Private Use").

>   8) sec 10.4: i Wonder if an RFC-required policy wouldn’t be more appropriate
>   for the VersionedTransTypes registry?

In 6962-bis section 10.4.1, we ask the appointed Expert to "review the public specification to ensure that it is detailed enough to ensure implementation interoperability".

AFAICT from RFC8126, "RFC Required" doesn't imply Expert Review, whereas "Specification Required" does.  So I think we should leave it as "Specification Required".

>   9) sec 10.6.1:I guess  the registration policy is FCFS? RFC 8126 recommend to
>   always (clearly) name the registry.

Thanks.  In our response to Alissa Cooper's DISCUSS/COMMENTs (see https://github.com/google/certificate-transparency-rfcs/pull/309), we've already clarified that the Log ID Registry is indeed First Come First Served.

> And finally one higher level question mainly out of curiosity: was it
> considered to e.g. use json for all data structures? Is there a performance
> reason to not do that or wasn’t that even discussed?

Please don't restart the format wars.  ;-)

We must use ASN.1 for all data structures, because X.509 certificates are involved.  But we must use "TLS encoding" for all data structures, because TLS is involved.  But we must use JSON for all data structures, because JSON is more API-friendly.

It was impossible to please everyone.  We had to choose something, so we chose TLS encoding for the data structures, and JSON for the APIs.

As I mentioned earlier, one goal of 6962-bis is to make log artifacts smaller.  TLS encoding is more suited to this than JSON.