### PR TITLE
Add section on TLS server

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -1827,6 +1827,14 @@ that are mandatory to implement for CT-using TLS clients (see
 if it did not include both the `transparency_info` and `status_request` TLS
 extensions in the ClientHello.
 
+## TLS Server {#no_tls_servers}
+
+This specification includes no description of what a TLS server should
+do if it wants to verify a received TLS client certificate.
+While this may be useful, it is not documented here because the greater
+security exposure is for clients to end up interacting with an illegitimate
+server. A future version could include such information.
+
 ## Monitor {#monitor}
 
 Monitors watch logs to check that they behave correctly, for certificates of

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -1601,6 +1601,20 @@ Three mechanisms are provided because they have different tradeoffs.
   subsequently consider the certificate to be non-compliant and in need of
   re-issuance.
 
+## TLS Client Authentication
+
+This specification includes no description of how a TLS server can
+use CT for TLS client certificates.
+While this may be useful, it is not documented here for the following
+reasons:
+
+* The greater security exposure is for clients to end up interacting with an
+  illegitimate server.
+* In general, TLS client certificates are not expected to be submitted to
+  CT logs, particularly those intended for general public use.
+
+A future version could include such information.
+
 ## Multiple SCTs {#multiple-scts}
 
 CT-using TLS servers SHOULD send SCTs from multiple logs, because:
@@ -1826,14 +1840,6 @@ that are mandatory to implement for CT-using TLS clients (see
 {{receiving_transitems}}). Therefore, a TLS client MUST NOT evaluate compliance
 if it did not include both the `transparency_info` and `status_request` TLS
 extensions in the ClientHello.
-
-## TLS Server {#no_tls_servers}
-
-This specification includes no description of what a TLS server should
-do if it wants to verify a received TLS client certificate.
-While this may be useful, it is not documented here because the greater
-security exposure is for clients to end up interacting with an illegitimate
-server. A future version could include such information.
 
 ## Monitor {#monitor}
 


### PR DESCRIPTION
Explain why server-side isn't discussed.  I.e., non-use of CT for TLS client certificates.