### PR TITLE
Mirja comments

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -869,7 +869,8 @@ Each log is identified by an OID, which is one of the log's parameters (see
 {{log_parameters}}) and which MUST NOT be used to identify any other log. A
 log's operator MUST either allocate the OID themselves or request an OID from
 the Log ID Registry (see {{log_id_registry}}).
-(Recall that OID's are do not require a central registration, although
+The only advantage of the registry is that the DER encoding can be small.
+(Recall that OID allocations do not require a central registration, although
 logs will most likely want to make themselves known to potential clients
 through out of band means.)
 Various data structures include

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -1257,6 +1257,7 @@ responses as transient failures and MAY retry the same request without
 modification at a later date. Note that as per [RFC7231], in the case of a 503
 response the log MAY include a `Retry-After:` header in order to request a
 minimum time for the client to wait before retrying the request.
+In the absence of this header, this document does not specify a minimum.
 
 ## Submit Entry to Log {#submit-entry}
 
@@ -1550,6 +1551,9 @@ Logs MAY restrict the number of entries that can be retrieved per `get-entries`
 request. If a client requests more than the permitted number of entries, the log
 SHALL return the maximum number of entries permissible. These entries SHALL be
 sequential beginning with the entry specified by `start`.
+Note that limit on the number of entries is not immutable and therefore
+the restriction may be changed or lifted at any time and is not listed
+with the other Log Parameters in {{log_parameters}}.
 
 Because of skew, it is possible the log server will not have any entries between
 `start` and `end`. In this case it MUST return an empty `entries` array.

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -2019,7 +2019,21 @@ the log.
 ## Signature Algorithms {#signature_algorithms}
 
 IANA is asked to establish a registry of signature algorithm values, named
-"CT Signature Algorithms", that initially consists of:
+"CT Signature Algorithms"
+
+The following notes should be added:
+
+- This is a subset of the TLS SignatureScheme Registry, limited to those
+algorithms that are appropriate for CT. A major advantage of this is
+leveraging the expertise of the TLS working group and its designated
+experts.
+
+- The value `0x0403` appears twice. While this may be confusing,
+it is okay because the verification
+process is the same for both algorithms, and the choice of which to use
+when generating a signature is purely internal to the log server.
+
+The registry should initially consist of:
 
 |--------------------------------+----------------------------------------------------+-------------------------------|
 | SignatureScheme Value          | Signature Algorithm                                | Reference / Assignment Policy |

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -1024,8 +1024,10 @@ which encapsulates a `SignedCertificateTimestampDataV2` structure:
 `sct_extensions` is a vector of 0 or more SCT extensions. This vector MUST NOT
 include more than one extension with the same `extension_type`. The
 extensions in the vector MUST be ordered by the value of the
-`extension_type` field, smallest value first. If an implementation sees an
-extension that it does not understand, it SHOULD ignore that extension.
+`extension_type` field, smallest value first.
+All SCT extensions are similar to non-critical X.509v3 extensions (i.e.,
+the `mustUnderstand` field is not set), and a recipient SHOULD ignore any
+extension it does not understand.
 Furthermore, an implementation MAY choose to ignore any extension(s) that it
 does understand.
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -868,7 +868,11 @@ chain that the log used to verify the submission.
 Each log is identified by an OID, which is one of the log's parameters (see
 {{log_parameters}}) and which MUST NOT be used to identify any other log. A
 log's operator MUST either allocate the OID themselves or request an OID from
-the Log ID Registry (see {{log_id_registry}}). Various data structures include
+the Log ID Registry (see {{log_id_registry}}).
+(Recall that OID's are do not require a central registration, although
+logs will most likely want to make themselves known to potential clients
+through out of band means.)
+Various data structures include
 the DER encoding of this OID, excluding the ASN.1 tag and length bytes, in an
 opaque vector:
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -52,6 +52,7 @@ normative:
   RFC8032:
   RFC8174:
   RFC8259:
+  RFC8391:
   RFC8446:
   HTML401:
     target: http://www.w3.org/TR/1999/REC-html401-19991224
@@ -265,6 +266,12 @@ major changes are:
 # Cryptographic Components
 
 ## Merkle Hash Trees {#mht}
+
+A full description of Merkle Hash Tree is beyond the scope of this
+document. Briefly, it is a binary tree where each non-leaf node is a
+hash of its children. For CT, the number of children is at most two.
+Additional information can be found in the Introduction and Reference
+section of {{!RFC8391}}.
 
 ### Definition of the Merkle Tree {#mht_definition}
 


### PR DESCRIPTION
This addresses the comments Mirja had during IESG review.  No changes were made for the following:
```
 7) sec 10.3: Couldn’t you use the TLS  SignatureScheme Registry directly (instead of forming an own registry)?

 8) sec 10.4: i Wonder if an RFC-required policy wouldn’t be more appropriate for the VersionedTransTypes registry?

 9) sec 10.6.1:I guess  the registration policy is FCFS? RFC 8126 recommend to always (clearly) name the registry.

And finally one higher level question mainly out of curiosity: was it considered to e.g. use json for all data structures? Is there a performance reason to not do that or wasn’t that even discussed?
```

Replies:
7 Using the TLS registry is not appropriate, the signatures are for different protocols even though the algorithm is the same
8 No.
9. OID's are FCFS and they're not really a registry.
Finally: signed json structures are complex and time-consuming, in addition to the verbosity over binary structures