### PR TITLE
Remove refs to draft-ietf-trans-threat-analysis

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -119,7 +119,6 @@ informative:
     author:
       org: The Chromium Projects
     date: 2014
-  I-D.ietf-trans-threat-analysis:
 
 --- abstract
 
@@ -2190,9 +2189,6 @@ owners will have a greater incentive to submit certificates to logs, possibly
 with the assistance of their CA, increasing the overall transparency of the
 system.
 
-[I-D.ietf-trans-threat-analysis] provides a more detailed threat analysis of the
-Certificate Transparency architecture.
-
 ## Misissued Certificates
 
 Misissued certificates that have not been publicly logged, and thus do not have
@@ -2215,8 +2211,7 @@ certificate with an SCT in the Merkle Tree within the MMD; presenting different,
 conflicting views of the Merkle Tree at different times and/or to different
 parties; issuing STHs too frequently; mutating the signature of a logged
 certificate; and failing to present a chain containing the certifier of a logged
-certificate. Such misbehavior is detectable and [I-D.ietf-trans-threat-analysis]
-provides more details on how this can be done.
+certificate.
 
 Violation of the MMD contract is detected by log clients requesting a Merkle
 inclusion proof ({{get-proof-by-hash}}) for each observed SCT. These checks can


### PR DESCRIPTION
Since the threat-analysis draft is also dead, remove references to it.