### PR TITLE
Clarify IANA actions (Murray's feedback)

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -2083,17 +2083,17 @@ Index value: No transformation needed.
 
 ## New CT-Related registries
 
-IANA is requisted to add a new protocol registry, "Certificate
-Transparency (CT)", to the list that appears at
+IANA is requisted to add a new protocol registry, "Public Notary
+Transparency", to the list that appears at
 https://www.iana.org/assignments/
 
 The reset of this section defines registries, or sub-registries, to be
 created within the new Certificate Transparency registry.
 
-### CT Hash Algorithms {#hash_algorithms}
+### Hash Algorithms {#hash_algorithms}
 
 IANA is asked to establish a registry of hash algorithm values, named
-"CT Hash Algorithms", that initially consists of:
+"Hash Algorithms", that initially consists of:
 
 |-------------+----------------+------------------------+-------------------------------|
 | Value       | Hash Algorithm | OID                    | Reference / Assignment Policy |
@@ -2109,10 +2109,10 @@ specification and is suitable for use as a cryptographic hash algorithm with no
 known preimage or collision attacks. These attacks can damage the integrity of
 the log.
 
-### CT Signature Algorithms {#signature_algorithms}
+### Signature Algorithms {#signature_algorithms}
 
 IANA is asked to establish a registry of signature algorithm values, named
-"CT Signature Algorithms".
+"Signature Algorithms".
 
 The following notes should be added:
 
@@ -2143,13 +2143,13 @@ The registry should initially consist of:
 
 The Designated Expert(s) should ensure that the proposed algorithm has a public
 specification, has a value assigned to it in the TLS SignatureScheme Registry
-(that IANA is asked to establish in [RFC8446]) and is suitable for use as a
+(that IANA was asked to establish in [RFC8446]) and is suitable for use as a
 cryptographic signature algorithm.
 
-### CT VersionedTransTypes {#versioned_trans_types}
+### VersionedTransTypes {#versioned_trans_types}
 
 IANA is asked to establish a registry of `VersionedTransType` values, named
-"CT VersionedTransTypes".
+"VersionedTransTypes".
 
 The following note should be added:
 
@@ -2177,9 +2177,9 @@ The registry should initially consist of:
 The Designated Expert(s) should review the public specification to ensure that it is
 detailed enough to ensure implementation interoperability.
 
-### CT Log Artifact Extension Registry {#log_artifact_extension_registry}
+### Log Artifact Extension Registry {#log_artifact_extension_registry}
 
-IANA is asked to establish a registry of `ExtensionType` values, named "CT Log
+IANA is asked to establish a registry of `ExtensionType` values, named "Log
 Artifact Extensions", that initially consists of:
 
 |-----------------+------------+-----+-------------------------------|
@@ -2201,9 +2201,9 @@ detailed enough to ensure implementation interoperability. They should
 also verify that the extension is appropriate to the contexts in which it is
 specified to be used (SCT, STH, or both).
 
-### CT Log ID Registry {#log_id_registry}
+### Log ID Registry {#log_id_registry}
 
-IANA is asked to establish a registry of Log IDs, named "CT Log ID Registry",
+IANA is asked to establish a registry of Log IDs, named "Log ID Registry",
 that initially consists of:
 
 |------------------------------+--------------+--------------+-------------------------------|
@@ -2238,10 +2238,10 @@ details in this registry.
 Since log operators can choose to not use this registry (see {{log_id}}), it is
 not expected to be a global directory of all logs.
 
-### CT Error Types Registry
+### Error Types Registry
 
 IANA is requested to create a new registry for errors,
-the "CT Error Types" registry.
+the "Error Types" registry.
 
 Requirements for this registry are Specification Required.
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -2083,12 +2083,12 @@ Index value: No transformation needed.
 
 ## New CT-Related registries
 
-IANA is requisted to add a new protocol registry, "Public Notary
+IANA is requested to add a new protocol registry, "Public Notary
 Transparency", to the list that appears at
 https://www.iana.org/assignments/
 
-The reset of this section defines registries, or sub-registries, to be
-created within the new Certificate Transparency registry.
+The rest of this section defines sub-registries to be
+created within the new Public Notary Transparency registry.
 
 ### Hash Algorithms {#hash_algorithms}
 

--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -230,6 +230,12 @@ when, and only when, they appear in all capitals, as shown here.
 Data structures are defined and encoded according to the conventions laid out
 in Section 3 of [RFC8446].
 
+This document uses object identifiers (OIDs) to identify Log IDs (see
+{{log_id}}), the precertificate CMS `eContentType` (see {{precertificates}}),
+and X.509v3 extensions in certificates (see {{cert_transinfo_extension}}) and
+OCSP responses (see {{ocsp_transinfo_extension}}). The OIDs are defined in an
+arc that was selected due to its short encoding.
+
 ## Major Differences from CT 1.0
 
 This document revises and obsoletes the CT 1.0 [RFC6962] protocol, drawing on
@@ -2077,10 +2083,14 @@ Index value: No transformation needed.
 
 ## New CT-Related registries
 
-This sub-section defines new registries for CT.
-They should be made available at https://www.iana.org/assignments/
+IANA is requisted to add a new protocol registry, "Certificate
+Transparency (CT)", to the list that appears at
+https://www.iana.org/assignments/
 
-### Hash Algorithms {#hash_algorithms}
+The reset of this section defines registries, or sub-registries, to be
+created within the new Certificate Transparency registry.
+
+### CT Hash Algorithms {#hash_algorithms}
 
 IANA is asked to establish a registry of hash algorithm values, named
 "CT Hash Algorithms", that initially consists of:
@@ -2099,7 +2109,7 @@ specification and is suitable for use as a cryptographic hash algorithm with no
 known preimage or collision attacks. These attacks can damage the integrity of
 the log.
 
-### Signature Algorithms {#signature_algorithms}
+### CT Signature Algorithms {#signature_algorithms}
 
 IANA is asked to establish a registry of signature algorithm values, named
 "CT Signature Algorithms".
@@ -2136,15 +2146,22 @@ specification, has a value assigned to it in the TLS SignatureScheme Registry
 (that IANA is asked to establish in [RFC8446]) and is suitable for use as a
 cryptographic signature algorithm.
 
-### VersionedTransTypes {#versioned_trans_types}
+### CT VersionedTransTypes {#versioned_trans_types}
 
 IANA is asked to establish a registry of `VersionedTransType` values, named
-"CT VersionedTransTypes", that initially consists of:
+"CT VersionedTransTypes".
+
+The following note should be added:
+
+- The 0x0000 value is reserved so that v1 SCTs are distinguishable from v2
+SCTs and other `TransItem` structures.
+
+The registry should initially consist of:
 
 |-----------------+---------------------------+-------------------------------|
 | Value           | Type and Version          | Reference / Assignment Policy |
 |-----------------+---------------------------+-------------------------------|
-| 0x0000          | Reserved                  | [RFC6962] \*                  |
+| 0x0000          | Reserved                  | [RFC6962]                     |
 | 0x0001          | x509_entry_v2             | RFCXXXX                       |
 | 0x0002          | precert_entry_v2          | RFCXXXX                       |
 | 0x0003          | x509_sct_v2               | RFCXXXX                       |
@@ -2157,13 +2174,10 @@ IANA is asked to establish a registry of `VersionedTransType` values, named
 | 0xF000 - 0xFFFF | Reserved                  | Private Use                   |
 |-----------------+---------------------------+-------------------------------|
 
-\* The 0x0000 value is reserved so that v1 SCTs are distinguishable from v2
-SCTs and other `TransItem` structures.
-
 The Designated Expert(s) should review the public specification to ensure that it is
 detailed enough to ensure implementation interoperability.
 
-### Log Artifact Extension Registry {#log_artifact_extension_registry}
+### CT Log Artifact Extension Registry {#log_artifact_extension_registry}
 
 IANA is asked to establish a registry of `ExtensionType` values, named "CT Log
 Artifact Extensions", that initially consists of:
@@ -2187,15 +2201,7 @@ detailed enough to ensure implementation interoperability. They should
 also verify that the extension is appropriate to the contexts in which it is
 specified to be used (SCT, STH, or both).
 
-### Object Identifiers
-
-This document uses object identifiers (OIDs) to identify Log IDs (see
-{{log_id}}), the precertificate CMS `eContentType` (see {{precertificates}}),
-and X.509v3 extensions in certificates (see {{cert_transinfo_extension}}) and
-OCSP responses (see {{ocsp_transinfo_extension}}). The OIDs are defined in an
-arc that was selected due to its short encoding.
-
-#### Log ID Registry {#log_id_registry}
+### CT Log ID Registry {#log_id_registry}
 
 IANA is asked to establish a registry of Log IDs, named "CT Log ID Registry",
 that initially consists of:


### PR DESCRIPTION
Move the OId text up, and out of the IANA section.
Add clarification that a new "Certificate Transparency" protocol
registry is being created, and six registries within it.