### PR TITLE
Log IDs don't have to be managed by the IANA registry.

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -255,7 +255,7 @@ major changes are:
   needed.
 
 - Logs IDs: each log is now identified by an OID rather than by the hash of its
-  public key. OID allocations are managed by an IANA registry.
+  public key. OID allocations are available from an IANA registry.
 
 - `TransItem` structure: this new data structure is used to encapsulate most
   types of CT data. A `TransItemList`, consisting of one or more `TransItem`


### PR DESCRIPTION
In the "Major Differences from CT 1.0" section, _"Logs IDs: ... OID allocations are managed by an IANA registry"_ seems to suggest that every Log ID MUST be allocated by the Log IDs Registry, which isn't the case.  Use of the Log IDs Registry is optional.

Let's apply this editorial change during AUTH48.