### PR TITLE
Register entire TRANS namespace, not just trans:error.

### DIFF
--- a/draft-ietf-trans-rfc6962-bis.md
+++ b/draft-ietf-trans-rfc6962-bis.md
@@ -2077,13 +2077,13 @@ Value | Extension Name    | TLS 1.3    | Recommended | Reference |
 TBD   | transparency_info | CH, CR, CT | Y           | RFCXXXX   |
 +-----|-------------------|------------|-------------|-----------+
 
-### URN Sub-namespace for TRANS errors (urn:ietf:params:trans:error)
+### URN Sub-namespace for TRANS (urn:ietf:params:trans)
 
 IANA is requested to add a new entry in the
 "IETF URN Sub-namespace for Registered Protocol Parameter Identifiers"
 registry, following the template in {{!RFC3553}}:
 
-Registry name: trans:error
+Registry name: trans
 
 Specification: RFCXXXX
 


### PR DESCRIPTION
This PR aligns our "IETF URN Sub-namespace for Registered Protocol Parameter Identifiers" registration with the approach taken by ACME (RFC8555), which was our original intent.

Although 6962-bis only uses `trans:error`, it's possible that future extensions might want to use `trans:<something_else>`.